### PR TITLE
Enhance website visuals: icons, spacing, text reduction

### DIFF
--- a/public/icons/desk.svg
+++ b/public/icons/desk.svg
@@ -8,19 +8,26 @@
 
     <!-- Routing line gradient — accent trace -->
     <linearGradient id="d-route" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#4A8FBF" stop-opacity="0.8"/>
+      <stop offset="0%" stop-color="#4A8FBF" stop-opacity="0.85"/>
       <stop offset="100%" stop-color="#4A8FBF" stop-opacity="0.2"/>
     </linearGradient>
 
-    <!-- SLA bar fill gradient -->
+    <!-- SLA bar — warning fill -->
     <linearGradient id="d-sla-warn" x1="0" y1="0" x2="1" y2="0">
       <stop offset="0%" stop-color="#D68910" stop-opacity="0.7"/>
-      <stop offset="100%" stop-color="#D68910" stop-opacity="0.3"/>
+      <stop offset="100%" stop-color="#D68910" stop-opacity="0.2"/>
     </linearGradient>
 
+    <!-- SLA bar — pass fill -->
     <linearGradient id="d-sla-ok" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#1E8449" stop-opacity="0.7"/>
-      <stop offset="100%" stop-color="#1E8449" stop-opacity="0.3"/>
+      <stop offset="0%" stop-color="#1E8449" stop-opacity="0.65"/>
+      <stop offset="100%" stop-color="#1E8449" stop-opacity="0.2"/>
+    </linearGradient>
+
+    <!-- Critical row subtle tint -->
+    <linearGradient id="d-row-crit" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#C0392B" stop-opacity="0.1"/>
+      <stop offset="100%" stop-color="#C0392B" stop-opacity="0"/>
     </linearGradient>
 
     <clipPath id="d-clip">
@@ -31,9 +38,9 @@
   <!-- ── Outer frame ─────────────────────────────────────────── -->
   <rect x="4" y="4" width="112" height="112" fill="url(#d-bg)" stroke="#243040" stroke-width="1"/>
 
-  <!-- Corner cut mark — top right -->
+  <!-- Corner cut mark — top right (accent) -->
   <polyline points="96,4 112,4 112,20" stroke="#4A8FBF" stroke-width="1" opacity="0.6"/>
-  <!-- Corner mark — bottom left -->
+  <!-- Corner mark — bottom left (dim) -->
   <polyline points="24,116 4,116 4,100" stroke="#243040" stroke-width="1" opacity="0.5"/>
 
   <g clip-path="url(#d-clip)">
@@ -41,159 +48,176 @@
     <!-- ── Header bar ─────────────────────────────────────────── -->
     <rect x="4" y="4" width="112" height="14" fill="#0D1117"/>
     <line x1="4" y1="18" x2="116" y2="18" stroke="#243040" stroke-width="0.75"/>
-    <!-- Status dot — pass -->
-    <rect x="10" y="9" width="4" height="4" fill="#1E8449"/>
+    <!-- Status dot — warning (1 SLA breach) -->
+    <rect x="10" y="9" width="4" height="4" fill="#D68910"/>
     <!-- Header labels -->
-    <rect x="18" y="10" width="20" height="2" fill="#5A7184" opacity="0.6"/>
-    <rect x="42" y="10" width="10" height="2" fill="#3A4F61" opacity="0.5"/>
+    <rect x="18" y="10" width="18" height="2" fill="#5A7184" opacity="0.6"/>
+    <rect x="40" y="10" width="10" height="2" fill="#3A4F61" opacity="0.5"/>
     <!-- Right label -->
-    <rect x="84" y="10" width="26" height="2" fill="#3A4F61" opacity="0.4"/>
+    <rect x="86" y="10" width="24" height="2" fill="#3A4F61" opacity="0.4"/>
 
-    <!-- ── Column headers ─────────────────────────────────────── -->
-    <rect x="4" y="18" width="112" height="11" fill="#131920"/>
-    <line x1="4" y1="29" x2="116" y2="29" stroke="#1A2230" stroke-width="0.75"/>
+    <!-- ── Column headers row ─────────────────────────────────── -->
+    <rect x="4" y="18" width="112" height="10" fill="#131920"/>
+    <line x1="4" y1="28" x2="116" y2="28" stroke="#1A2230" stroke-width="0.75"/>
 
     <!-- Column header text blocks -->
-    <rect x="10" y="22" width="12" height="1.5" fill="#4A8FBF" opacity="0.5"/>
-    <rect x="38" y="22" width="16" height="1.5" fill="#3A4F61" opacity="0.4"/>
-    <rect x="66" y="22" width="10" height="1.5" fill="#3A4F61" opacity="0.4"/>
-    <rect x="88" y="22" width="14" height="1.5" fill="#3A4F61" opacity="0.4"/>
+    <rect x="10" y="21.5" width="10" height="1.5" fill="#4A8FBF" opacity="0.55"/>
+    <rect x="36" y="21.5" width="20" height="1.5" fill="#3A4F61" opacity="0.4"/>
+    <rect x="68" y="21.5" width="12" height="1.5" fill="#3A4F61" opacity="0.4"/>
+    <rect x="90" y="21.5" width="16" height="1.5" fill="#3A4F61" opacity="0.4"/>
 
-    <!-- Column separators -->
-    <line x1="34" y1="18" x2="34" y2="116" stroke="#1A2230" stroke-width="0.5"/>
-    <line x1="64" y1="18" x2="64" y2="116" stroke="#1A2230" stroke-width="0.5"/>
-    <line x1="84" y1="18" x2="84" y2="116" stroke="#1A2230" stroke-width="0.5"/>
+    <!-- Column separators — full height -->
+    <line x1="32"  y1="18" x2="32"  y2="80" stroke="#1A2230" stroke-width="0.5"/>
+    <line x1="64"  y1="18" x2="64"  y2="80" stroke="#1A2230" stroke-width="0.5"/>
+    <line x1="86"  y1="18" x2="86"  y2="80" stroke="#1A2230" stroke-width="0.5"/>
 
-    <!-- ── Ticket row 1 — CRITICAL, open ──────────────────────── -->
-    <rect x="4" y="29" width="112" height="13" fill="#131920" opacity="0.4"/>
-    <line x1="4" y1="42" x2="116" y2="42" stroke="#1A2230" stroke-width="0.5"/>
+    <!-- ══════════════════════════════════════════════════════════
+         TICKET ROWS
+         Columns: [PRIORITY+ID | SUMMARY | CATEGORY | SLA]
+         ══════════════════════════════════════════════════════════ -->
+
+    <!-- ── Row 1 — CRITICAL, open, overdue ───────────────────── -->
+    <rect x="4" y="28" width="112" height="13" fill="url(#d-row-crit)"/>
+    <line x1="4" y1="41" x2="116" y2="41" stroke="#1A2230" stroke-width="0.5"/>
 
     <!-- Priority indicator — critical square -->
-    <rect x="10" y="34" width="4" height="4" fill="#C0392B"/>
-    <!-- Ticket ID block -->
-    <rect x="17" y="34" width="10" height="2" fill="#5A7184" opacity="0.5"/>
+    <rect x="10" y="33" width="4" height="4" fill="#C0392B"/>
+    <!-- Ticket ID -->
+    <rect x="17" y="33.5" width="10" height="1.5" fill="#5A7184" opacity="0.5"/>
 
-    <!-- Summary text block -->
-    <rect x="38" y="32" width="20" height="2" fill="#E8EDF2" opacity="0.55"/>
-    <rect x="38" y="37" width="14" height="1.5" fill="#5A7184" opacity="0.35"/>
+    <!-- Summary line 1 + 2 -->
+    <rect x="36" y="30" width="22" height="2" fill="#E8EDF2" opacity="0.55"/>
+    <rect x="36" y="34.5" width="15" height="1.5" fill="#5A7184" opacity="0.32"/>
 
-    <!-- Category badge — small rect -->
-    <rect x="66" y="33" width="12" height="5" fill="none" stroke="#C0392B" stroke-width="0.75" opacity="0.7"/>
-    <rect x="67" y="34.5" width="8" height="1.5" fill="#C0392B" opacity="0.4"/>
+    <!-- Category badge -->
+    <rect x="67" y="31" width="14" height="6" fill="none" stroke="#C0392B" stroke-width="0.75" opacity="0.7"/>
+    <rect x="68" y="32.5" width="10" height="2" fill="#C0392B" opacity="0.35"/>
 
-    <!-- SLA bar — overdue, red fill -->
-    <rect x="87" y="33" width="22" height="5" fill="none" stroke="#243040" stroke-width="0.5"/>
-    <rect x="87" y="33" width="22" height="5" fill="#C0392B" opacity="0.25"/>
-    <rect x="87" y="33" width="22" height="5" fill="none" stroke="#C0392B" stroke-width="0.5" opacity="0.5"/>
+    <!-- SLA bar — overdue/full critical -->
+    <rect x="89" y="31" width="22" height="6" fill="none" stroke="#C0392B" stroke-width="0.5" opacity="0.6"/>
+    <rect x="89" y="31" width="22" height="6" fill="#C0392B" opacity="0.2"/>
+    <!-- OVER marker line -->
+    <line x1="111" y1="31" x2="111" y2="37" stroke="#C0392B" stroke-width="1" opacity="0.7"/>
 
-    <!-- ── Ticket row 2 — WARNING, in progress ────────────────── -->
-    <line x1="4" y1="55" x2="116" y2="55" stroke="#1A2230" stroke-width="0.5"/>
-    <rect x="10" y="47" width="4" height="4" fill="#D68910"/>
-    <rect x="17" y="47" width="10" height="2" fill="#5A7184" opacity="0.5"/>
+    <!-- ── Row 2 — WARNING, in-progress ──────────────────────── -->
+    <line x1="4" y1="54" x2="116" y2="54" stroke="#1A2230" stroke-width="0.5"/>
+    <rect x="10" y="46" width="4" height="4" fill="#D68910"/>
+    <rect x="17" y="46.5" width="10" height="1.5" fill="#5A7184" opacity="0.5"/>
 
-    <rect x="38" y="45" width="22" height="2" fill="#E8EDF2" opacity="0.45"/>
-    <rect x="38" y="50" width="16" height="1.5" fill="#5A7184" opacity="0.3"/>
+    <rect x="36" y="43" width="24" height="2" fill="#E8EDF2" opacity="0.45"/>
+    <rect x="36" y="47.5" width="18" height="1.5" fill="#5A7184" opacity="0.28"/>
 
-    <rect x="66" y="46" width="12" height="5" fill="none" stroke="#D68910" stroke-width="0.75" opacity="0.6"/>
-    <rect x="67" y="47.5" width="8" height="1.5" fill="#D68910" opacity="0.35"/>
+    <rect x="67" y="44" width="14" height="6" fill="none" stroke="#D68910" stroke-width="0.75" opacity="0.6"/>
+    <rect x="68" y="45.5" width="10" height="2" fill="#D68910" opacity="0.3"/>
 
-    <!-- SLA bar — warning, partial fill -->
-    <rect x="87" y="46" width="22" height="5" fill="none" stroke="#243040" stroke-width="0.5"/>
-    <rect x="87" y="46" width="14" height="5" fill="url(#d-sla-warn)"/>
+    <!-- SLA bar — warning, ~65% consumed -->
+    <rect x="89" y="44" width="22" height="6" fill="none" stroke="#243040" stroke-width="0.5"/>
+    <rect x="89" y="44" width="14" height="6" fill="url(#d-sla-warn)"/>
 
-    <!-- ── Ticket row 3 — PASS, resolved ─────────────────────── -->
-    <line x1="4" y1="68" x2="116" y2="68" stroke="#1A2230" stroke-width="0.5"/>
-    <rect x="10" y="60" width="4" height="4" fill="#1E8449"/>
-    <rect x="17" y="60" width="10" height="2" fill="#5A7184" opacity="0.5"/>
+    <!-- ── Row 3 — PASS, resolved ─────────────────────────────── -->
+    <line x1="4" y1="67" x2="116" y2="67" stroke="#1A2230" stroke-width="0.5"/>
+    <rect x="10" y="59" width="4" height="4" fill="#1E8449"/>
+    <rect x="17" y="59.5" width="10" height="1.5" fill="#5A7184" opacity="0.45"/>
 
-    <rect x="38" y="58" width="18" height="2" fill="#E8EDF2" opacity="0.35"/>
-    <rect x="38" y="63" width="12" height="1.5" fill="#5A7184" opacity="0.25"/>
+    <rect x="36" y="56" width="18" height="2" fill="#E8EDF2" opacity="0.35"/>
+    <rect x="36" y="60.5" width="12" height="1.5" fill="#5A7184" opacity="0.22"/>
 
-    <rect x="66" y="59" width="12" height="5" fill="none" stroke="#1E8449" stroke-width="0.75" opacity="0.5"/>
-    <rect x="67" y="60.5" width="8" height="1.5" fill="#1E8449" opacity="0.3"/>
+    <rect x="67" y="57" width="14" height="6" fill="none" stroke="#1E8449" stroke-width="0.75" opacity="0.5"/>
+    <rect x="68" y="58.5" width="10" height="2" fill="#1E8449" opacity="0.25"/>
 
     <!-- SLA bar — resolved, full green -->
-    <rect x="87" y="59" width="22" height="5" fill="none" stroke="#243040" stroke-width="0.5"/>
-    <rect x="87" y="59" width="22" height="5" fill="url(#d-sla-ok)"/>
+    <rect x="89" y="57" width="22" height="6" fill="none" stroke="#243040" stroke-width="0.5"/>
+    <rect x="89" y="57" width="22" height="6" fill="url(#d-sla-ok)"/>
 
-    <!-- ── Ticket row 4 — INFO ────────────────────────────────── -->
-    <line x1="4" y1="81" x2="116" y2="81" stroke="#1A2230" stroke-width="0.5"/>
-    <rect x="10" y="73" width="4" height="4" fill="#2471A3"/>
-    <rect x="17" y="73" width="10" height="2" fill="#5A7184" opacity="0.5"/>
+    <!-- ── Row 4 — INFO ────────────────────────────────────────── -->
+    <line x1="4" y1="80" x2="116" y2="80" stroke="#243040" stroke-width="0.75"/>
+    <rect x="10" y="72" width="4" height="4" fill="#2471A3"/>
+    <rect x="17" y="72.5" width="10" height="1.5" fill="#5A7184" opacity="0.4"/>
 
-    <rect x="38" y="71" width="24" height="2" fill="#E8EDF2" opacity="0.3"/>
-    <rect x="38" y="76" width="18" height="1.5" fill="#5A7184" opacity="0.22"/>
+    <rect x="36" y="69" width="26" height="2" fill="#E8EDF2" opacity="0.28"/>
+    <rect x="36" y="73.5" width="20" height="1.5" fill="#5A7184" opacity="0.2"/>
 
-    <rect x="66" y="72" width="12" height="5" fill="none" stroke="#2471A3" stroke-width="0.75" opacity="0.5"/>
-    <rect x="67" y="73.5" width="8" height="1.5" fill="#2471A3" opacity="0.3"/>
+    <rect x="67" y="70" width="14" height="6" fill="none" stroke="#2471A3" stroke-width="0.75" opacity="0.45"/>
+    <rect x="68" y="71.5" width="10" height="2" fill="#2471A3" opacity="0.25"/>
 
-    <!-- SLA bar — info, half -->
-    <rect x="87" y="72" width="22" height="5" fill="none" stroke="#243040" stroke-width="0.5"/>
-    <rect x="87" y="72" width="10" height="5" fill="#2471A3" opacity="0.2"/>
+    <!-- SLA bar — info, partial -->
+    <rect x="89" y="70" width="22" height="6" fill="none" stroke="#243040" stroke-width="0.5"/>
+    <rect x="89" y="70" width="9" height="6" fill="#2471A3" opacity="0.18"/>
 
-    <!-- ── AI routing console — bottom panel ─────────────────── -->
-    <rect x="4" y="81" width="112" height="35" fill="#0D1117"/>
-    <line x1="4" y1="81" x2="116" y2="81" stroke="#243040" stroke-width="0.75"/>
+    <!-- ══════════════════════════════════════════════════════════
+         AI ROUTING CONSOLE — bottom panel
+         ══════════════════════════════════════════════════════════ -->
+    <rect x="4" y="80" width="112" height="36" fill="#0D1117"/>
+    <line x1="4" y1="80" x2="116" y2="80" stroke="#243040" stroke-width="0.75"/>
 
     <!-- Console header label -->
-    <rect x="10" y="85" width="20" height="2" fill="#4A8FBF" opacity="0.5"/>
-    <!-- AI label accent line -->
-    <line x1="10" y1="85" x2="10" y2="87" stroke="#4A8FBF" stroke-width="1.5" opacity="0.7"/>
+    <rect x="10" y="84" width="22" height="2" fill="#4A8FBF" opacity="0.5"/>
+    <!-- AI accent bar -->
+    <line x1="10" y1="84" x2="10" y2="86" stroke="#4A8FBF" stroke-width="1.5" opacity="0.75"/>
 
-    <!-- Routing diagram — three input nodes routing to two outputs -->
+    <!-- Routing confidence score — far right mini-bar stack -->
+    <rect x="98" y="83" width="14" height="3" fill="none" stroke="#1A2230" stroke-width="0.5"/>
+    <rect x="98" y="83" width="12" height="3" fill="#1E8449" opacity="0.28"/>
 
-    <!-- Input nodes (tickets) -->
-    <rect x="12" y="91" width="8" height="5" fill="none" stroke="#243040" stroke-width="0.75"/>
-    <rect x="13" y="92.5" width="5" height="1.5" fill="#D68910" opacity="0.4"/>
+    <rect x="98" y="88" width="14" height="3" fill="none" stroke="#1A2230" stroke-width="0.5"/>
+    <rect x="98" y="88" width="7"  height="3" fill="#D68910" opacity="0.28"/>
 
-    <rect x="12" y="100" width="8" height="5" fill="none" stroke="#243040" stroke-width="0.75"/>
-    <rect x="13" y="101.5" width="5" height="1.5" fill="#4A8FBF" opacity="0.4"/>
+    <rect x="98" y="93" width="14" height="3" fill="none" stroke="#1A2230" stroke-width="0.5"/>
+    <rect x="98" y="93" width="14" height="3" fill="#C0392B" opacity="0.14"/>
 
-    <rect x="12" y="109" width="8" height="5" fill="none" stroke="#243040" stroke-width="0.75"/>
-    <rect x="13" y="110.5" width="5" height="1.5" fill="#5A7184" opacity="0.35"/>
+    <!-- ── Routing diagram ────────────────────────────────────── -->
+    <!-- INPUT NODES (incoming tickets) -->
 
-    <!-- Routing lines — angular, 90-degree bends (mission control style) -->
-    <!-- Input 1 → junction -->
-    <polyline points="20,93.5 38,93.5 38,97" stroke="url(#d-route)" stroke-width="0.75" fill="none"/>
-    <!-- Input 2 → junction -->
-    <polyline points="20,102.5 38,102.5 38,97" stroke="url(#d-route)" stroke-width="0.75" fill="none"/>
-    <!-- Input 3 → junction -->
-    <polyline points="20,111.5 38,111.5 38,103" stroke="#243040" stroke-width="0.75" fill="none"/>
+    <!-- Ticket node A — warning -->
+    <rect x="12" y="90" width="9" height="6" fill="none" stroke="#D68910" stroke-width="0.65" opacity="0.8"/>
+    <rect x="13" y="91.5" width="6" height="1.5" fill="#D68910" opacity="0.35"/>
 
-    <!-- Junction node — accent square -->
-    <rect x="35.5" y="95" width="5" height="5" fill="none" stroke="#4A8FBF" stroke-width="0.75"/>
-    <rect x="37" y="96.5" width="2" height="2" fill="#4A8FBF" opacity="0.8"/>
+    <!-- Ticket node B — accent -->
+    <rect x="12" y="100" width="9" height="6" fill="none" stroke="#4A8FBF" stroke-width="0.65" opacity="0.7"/>
+    <rect x="13" y="101.5" width="6" height="1.5" fill="#4A8FBF" opacity="0.35"/>
 
-    <!-- Junction node 2 -->
-    <rect x="35.5" y="101" width="5" height="5" fill="none" stroke="#243040" stroke-width="0.75"/>
+    <!-- Ticket node C — dim -->
+    <rect x="12" y="110" width="9" height="5" fill="none" stroke="#243040" stroke-width="0.5"/>
+    <rect x="13" y="111" width="6" height="1.5" fill="#5A7184" opacity="0.3"/>
 
-    <!-- Output routing lines -->
-    <!-- Junction 1 → Team A node -->
-    <polyline points="40.5,97.5 56,97.5 56,93.5 70,93.5" stroke="#4A8FBF" stroke-width="0.75" fill="none" opacity="0.7"/>
-    <!-- Junction 2 → Team B node -->
-    <polyline points="40.5,103.5 56,103.5 56,109 70,109" stroke="#243040" stroke-width="0.75" fill="none"/>
+    <!-- Horizontal lines from input nodes to junction bend -->
+    <!-- Node A → bend at x=30 -->
+    <polyline points="21,93 30,93 30,97" stroke="url(#d-route)" stroke-width="0.75" fill="none"/>
+    <!-- Node B → bend at x=30 -->
+    <polyline points="21,103 30,103 30,97" stroke="url(#d-route)" stroke-width="0.75" fill="none"/>
+    <!-- Node C → junction 2 (dim) -->
+    <polyline points="21,112.5 30,112.5 30,107" stroke="#1A2230" stroke-width="0.5" fill="none"/>
+
+    <!-- Junction node 1 — AI router, accent -->
+    <rect x="27" y="94" width="6" height="6" fill="none" stroke="#4A8FBF" stroke-width="0.75"/>
+    <rect x="28.5" y="95.5" width="3" height="3" fill="#4A8FBF" opacity="0.75"/>
+
+    <!-- Junction node 2 — dim router -->
+    <rect x="27" y="104" width="6" height="6" fill="none" stroke="#243040" stroke-width="0.75"/>
+    <rect x="28.5" y="105.5" width="3" height="3" fill="#3A4F61" opacity="0.4"/>
+
+    <!-- Output routing lines — with 90° bends -->
+    <!-- Junction 1 → Team A -->
+    <polyline points="33,97 48,97 48,93 62,93" stroke="#4A8FBF" stroke-width="0.75" fill="none" opacity="0.65"/>
+    <!-- Junction 1 → Team B (secondary) -->
+    <polyline points="33,97 48,97 48,108 62,108" stroke="#4A8FBF" stroke-width="0.5" fill="none" opacity="0.3"/>
+    <!-- Junction 2 → dim output -->
+    <polyline points="33,107 48,107 48,113 62,113" stroke="#1A2230" stroke-width="0.5" fill="none"/>
 
     <!-- Output nodes — team queues -->
-    <rect x="70" y="90" width="20" height="7" fill="none" stroke="#4A8FBF" stroke-width="0.75" opacity="0.7"/>
-    <rect x="72" y="91.5" width="6" height="1.5" fill="#4A8FBF" opacity="0.4"/>
-    <rect x="72" y="94" width="10" height="1.5" fill="#5A7184" opacity="0.3"/>
+    <!-- Team A — Security queue (accent) -->
+    <rect x="62" y="88" width="22" height="9" fill="none" stroke="#4A8FBF" stroke-width="0.75" opacity="0.7"/>
+    <rect x="64" y="89.5" width="8" height="1.5" fill="#4A8FBF" opacity="0.45"/>
+    <rect x="64" y="93"   width="14" height="1.5" fill="#5A7184" opacity="0.28"/>
 
-    <rect x="70" y="106" width="20" height="7" fill="none" stroke="#243040" stroke-width="0.75"/>
-    <rect x="72" y="107.5" width="6" height="1.5" fill="#5A7184" opacity="0.3"/>
-    <rect x="72" y="110" width="10" height="1.5" fill="#3A4F61" opacity="0.3"/>
+    <!-- Team B — Infra queue (dim) -->
+    <rect x="62" y="103" width="22" height="9" fill="none" stroke="#243040" stroke-width="0.75"/>
+    <rect x="64" y="104.5" width="8" height="1.5" fill="#5A7184" opacity="0.3"/>
+    <rect x="64" y="108"   width="12" height="1.5" fill="#3A4F61" opacity="0.25"/>
 
-    <!-- SLA micro-summary — far right column -->
-    <rect x="96" y="85" width="16" height="3" fill="none" stroke="#1A2230" stroke-width="0.5"/>
-    <rect x="96" y="85" width="12" height="3" fill="#1E8449" opacity="0.3"/>
-
-    <rect x="96" y="90" width="16" height="3" fill="none" stroke="#1A2230" stroke-width="0.5"/>
-    <rect x="96" y="90" width="7" height="3" fill="#D68910" opacity="0.3"/>
-
-    <rect x="96" y="95" width="16" height="3" fill="none" stroke="#1A2230" stroke-width="0.5"/>
-    <rect x="96" y="95" width="16" height="3" fill="#C0392B" opacity="0.15"/>
-
-    <rect x="96" y="100" width="9" height="1.5" fill="#3A4F61" opacity="0.4"/>
-    <rect x="96" y="103" width="12" height="1.5" fill="#3A4F61" opacity="0.3"/>
+    <!-- Team C — dim, lower -->
+    <rect x="62" y="113" width="22" height="3" fill="none" stroke="#1A2230" stroke-width="0.5"/>
+    <rect x="64" y="113.5" width="10" height="1.5" fill="#3A4F61" opacity="0.2"/>
 
   </g>
 

--- a/public/icons/desk.svg
+++ b/public/icons/desk.svg
@@ -1,0 +1,200 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" width="120" height="120" fill="none">
+  <defs>
+    <!-- Background panel gradient -->
+    <linearGradient id="d-bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0D1117"/>
+      <stop offset="100%" stop-color="#080B0F"/>
+    </linearGradient>
+
+    <!-- Routing line gradient — accent trace -->
+    <linearGradient id="d-route" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#4A8FBF" stop-opacity="0.8"/>
+      <stop offset="100%" stop-color="#4A8FBF" stop-opacity="0.2"/>
+    </linearGradient>
+
+    <!-- SLA bar fill gradient -->
+    <linearGradient id="d-sla-warn" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#D68910" stop-opacity="0.7"/>
+      <stop offset="100%" stop-color="#D68910" stop-opacity="0.3"/>
+    </linearGradient>
+
+    <linearGradient id="d-sla-ok" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#1E8449" stop-opacity="0.7"/>
+      <stop offset="100%" stop-color="#1E8449" stop-opacity="0.3"/>
+    </linearGradient>
+
+    <clipPath id="d-clip">
+      <rect x="4" y="4" width="112" height="112"/>
+    </clipPath>
+  </defs>
+
+  <!-- ── Outer frame ─────────────────────────────────────────── -->
+  <rect x="4" y="4" width="112" height="112" fill="url(#d-bg)" stroke="#243040" stroke-width="1"/>
+
+  <!-- Corner cut mark — top right -->
+  <polyline points="96,4 112,4 112,20" stroke="#4A8FBF" stroke-width="1" opacity="0.6"/>
+  <!-- Corner mark — bottom left -->
+  <polyline points="24,116 4,116 4,100" stroke="#243040" stroke-width="1" opacity="0.5"/>
+
+  <g clip-path="url(#d-clip)">
+
+    <!-- ── Header bar ─────────────────────────────────────────── -->
+    <rect x="4" y="4" width="112" height="14" fill="#0D1117"/>
+    <line x1="4" y1="18" x2="116" y2="18" stroke="#243040" stroke-width="0.75"/>
+    <!-- Status dot — pass -->
+    <rect x="10" y="9" width="4" height="4" fill="#1E8449"/>
+    <!-- Header labels -->
+    <rect x="18" y="10" width="20" height="2" fill="#5A7184" opacity="0.6"/>
+    <rect x="42" y="10" width="10" height="2" fill="#3A4F61" opacity="0.5"/>
+    <!-- Right label -->
+    <rect x="84" y="10" width="26" height="2" fill="#3A4F61" opacity="0.4"/>
+
+    <!-- ── Column headers ─────────────────────────────────────── -->
+    <rect x="4" y="18" width="112" height="11" fill="#131920"/>
+    <line x1="4" y1="29" x2="116" y2="29" stroke="#1A2230" stroke-width="0.75"/>
+
+    <!-- Column header text blocks -->
+    <rect x="10" y="22" width="12" height="1.5" fill="#4A8FBF" opacity="0.5"/>
+    <rect x="38" y="22" width="16" height="1.5" fill="#3A4F61" opacity="0.4"/>
+    <rect x="66" y="22" width="10" height="1.5" fill="#3A4F61" opacity="0.4"/>
+    <rect x="88" y="22" width="14" height="1.5" fill="#3A4F61" opacity="0.4"/>
+
+    <!-- Column separators -->
+    <line x1="34" y1="18" x2="34" y2="116" stroke="#1A2230" stroke-width="0.5"/>
+    <line x1="64" y1="18" x2="64" y2="116" stroke="#1A2230" stroke-width="0.5"/>
+    <line x1="84" y1="18" x2="84" y2="116" stroke="#1A2230" stroke-width="0.5"/>
+
+    <!-- ── Ticket row 1 — CRITICAL, open ──────────────────────── -->
+    <rect x="4" y="29" width="112" height="13" fill="#131920" opacity="0.4"/>
+    <line x1="4" y1="42" x2="116" y2="42" stroke="#1A2230" stroke-width="0.5"/>
+
+    <!-- Priority indicator — critical square -->
+    <rect x="10" y="34" width="4" height="4" fill="#C0392B"/>
+    <!-- Ticket ID block -->
+    <rect x="17" y="34" width="10" height="2" fill="#5A7184" opacity="0.5"/>
+
+    <!-- Summary text block -->
+    <rect x="38" y="32" width="20" height="2" fill="#E8EDF2" opacity="0.55"/>
+    <rect x="38" y="37" width="14" height="1.5" fill="#5A7184" opacity="0.35"/>
+
+    <!-- Category badge — small rect -->
+    <rect x="66" y="33" width="12" height="5" fill="none" stroke="#C0392B" stroke-width="0.75" opacity="0.7"/>
+    <rect x="67" y="34.5" width="8" height="1.5" fill="#C0392B" opacity="0.4"/>
+
+    <!-- SLA bar — overdue, red fill -->
+    <rect x="87" y="33" width="22" height="5" fill="none" stroke="#243040" stroke-width="0.5"/>
+    <rect x="87" y="33" width="22" height="5" fill="#C0392B" opacity="0.25"/>
+    <rect x="87" y="33" width="22" height="5" fill="none" stroke="#C0392B" stroke-width="0.5" opacity="0.5"/>
+
+    <!-- ── Ticket row 2 — WARNING, in progress ────────────────── -->
+    <line x1="4" y1="55" x2="116" y2="55" stroke="#1A2230" stroke-width="0.5"/>
+    <rect x="10" y="47" width="4" height="4" fill="#D68910"/>
+    <rect x="17" y="47" width="10" height="2" fill="#5A7184" opacity="0.5"/>
+
+    <rect x="38" y="45" width="22" height="2" fill="#E8EDF2" opacity="0.45"/>
+    <rect x="38" y="50" width="16" height="1.5" fill="#5A7184" opacity="0.3"/>
+
+    <rect x="66" y="46" width="12" height="5" fill="none" stroke="#D68910" stroke-width="0.75" opacity="0.6"/>
+    <rect x="67" y="47.5" width="8" height="1.5" fill="#D68910" opacity="0.35"/>
+
+    <!-- SLA bar — warning, partial fill -->
+    <rect x="87" y="46" width="22" height="5" fill="none" stroke="#243040" stroke-width="0.5"/>
+    <rect x="87" y="46" width="14" height="5" fill="url(#d-sla-warn)"/>
+
+    <!-- ── Ticket row 3 — PASS, resolved ─────────────────────── -->
+    <line x1="4" y1="68" x2="116" y2="68" stroke="#1A2230" stroke-width="0.5"/>
+    <rect x="10" y="60" width="4" height="4" fill="#1E8449"/>
+    <rect x="17" y="60" width="10" height="2" fill="#5A7184" opacity="0.5"/>
+
+    <rect x="38" y="58" width="18" height="2" fill="#E8EDF2" opacity="0.35"/>
+    <rect x="38" y="63" width="12" height="1.5" fill="#5A7184" opacity="0.25"/>
+
+    <rect x="66" y="59" width="12" height="5" fill="none" stroke="#1E8449" stroke-width="0.75" opacity="0.5"/>
+    <rect x="67" y="60.5" width="8" height="1.5" fill="#1E8449" opacity="0.3"/>
+
+    <!-- SLA bar — resolved, full green -->
+    <rect x="87" y="59" width="22" height="5" fill="none" stroke="#243040" stroke-width="0.5"/>
+    <rect x="87" y="59" width="22" height="5" fill="url(#d-sla-ok)"/>
+
+    <!-- ── Ticket row 4 — INFO ────────────────────────────────── -->
+    <line x1="4" y1="81" x2="116" y2="81" stroke="#1A2230" stroke-width="0.5"/>
+    <rect x="10" y="73" width="4" height="4" fill="#2471A3"/>
+    <rect x="17" y="73" width="10" height="2" fill="#5A7184" opacity="0.5"/>
+
+    <rect x="38" y="71" width="24" height="2" fill="#E8EDF2" opacity="0.3"/>
+    <rect x="38" y="76" width="18" height="1.5" fill="#5A7184" opacity="0.22"/>
+
+    <rect x="66" y="72" width="12" height="5" fill="none" stroke="#2471A3" stroke-width="0.75" opacity="0.5"/>
+    <rect x="67" y="73.5" width="8" height="1.5" fill="#2471A3" opacity="0.3"/>
+
+    <!-- SLA bar — info, half -->
+    <rect x="87" y="72" width="22" height="5" fill="none" stroke="#243040" stroke-width="0.5"/>
+    <rect x="87" y="72" width="10" height="5" fill="#2471A3" opacity="0.2"/>
+
+    <!-- ── AI routing console — bottom panel ─────────────────── -->
+    <rect x="4" y="81" width="112" height="35" fill="#0D1117"/>
+    <line x1="4" y1="81" x2="116" y2="81" stroke="#243040" stroke-width="0.75"/>
+
+    <!-- Console header label -->
+    <rect x="10" y="85" width="20" height="2" fill="#4A8FBF" opacity="0.5"/>
+    <!-- AI label accent line -->
+    <line x1="10" y1="85" x2="10" y2="87" stroke="#4A8FBF" stroke-width="1.5" opacity="0.7"/>
+
+    <!-- Routing diagram — three input nodes routing to two outputs -->
+
+    <!-- Input nodes (tickets) -->
+    <rect x="12" y="91" width="8" height="5" fill="none" stroke="#243040" stroke-width="0.75"/>
+    <rect x="13" y="92.5" width="5" height="1.5" fill="#D68910" opacity="0.4"/>
+
+    <rect x="12" y="100" width="8" height="5" fill="none" stroke="#243040" stroke-width="0.75"/>
+    <rect x="13" y="101.5" width="5" height="1.5" fill="#4A8FBF" opacity="0.4"/>
+
+    <rect x="12" y="109" width="8" height="5" fill="none" stroke="#243040" stroke-width="0.75"/>
+    <rect x="13" y="110.5" width="5" height="1.5" fill="#5A7184" opacity="0.35"/>
+
+    <!-- Routing lines — angular, 90-degree bends (mission control style) -->
+    <!-- Input 1 → junction -->
+    <polyline points="20,93.5 38,93.5 38,97" stroke="url(#d-route)" stroke-width="0.75" fill="none"/>
+    <!-- Input 2 → junction -->
+    <polyline points="20,102.5 38,102.5 38,97" stroke="url(#d-route)" stroke-width="0.75" fill="none"/>
+    <!-- Input 3 → junction -->
+    <polyline points="20,111.5 38,111.5 38,103" stroke="#243040" stroke-width="0.75" fill="none"/>
+
+    <!-- Junction node — accent square -->
+    <rect x="35.5" y="95" width="5" height="5" fill="none" stroke="#4A8FBF" stroke-width="0.75"/>
+    <rect x="37" y="96.5" width="2" height="2" fill="#4A8FBF" opacity="0.8"/>
+
+    <!-- Junction node 2 -->
+    <rect x="35.5" y="101" width="5" height="5" fill="none" stroke="#243040" stroke-width="0.75"/>
+
+    <!-- Output routing lines -->
+    <!-- Junction 1 → Team A node -->
+    <polyline points="40.5,97.5 56,97.5 56,93.5 70,93.5" stroke="#4A8FBF" stroke-width="0.75" fill="none" opacity="0.7"/>
+    <!-- Junction 2 → Team B node -->
+    <polyline points="40.5,103.5 56,103.5 56,109 70,109" stroke="#243040" stroke-width="0.75" fill="none"/>
+
+    <!-- Output nodes — team queues -->
+    <rect x="70" y="90" width="20" height="7" fill="none" stroke="#4A8FBF" stroke-width="0.75" opacity="0.7"/>
+    <rect x="72" y="91.5" width="6" height="1.5" fill="#4A8FBF" opacity="0.4"/>
+    <rect x="72" y="94" width="10" height="1.5" fill="#5A7184" opacity="0.3"/>
+
+    <rect x="70" y="106" width="20" height="7" fill="none" stroke="#243040" stroke-width="0.75"/>
+    <rect x="72" y="107.5" width="6" height="1.5" fill="#5A7184" opacity="0.3"/>
+    <rect x="72" y="110" width="10" height="1.5" fill="#3A4F61" opacity="0.3"/>
+
+    <!-- SLA micro-summary — far right column -->
+    <rect x="96" y="85" width="16" height="3" fill="none" stroke="#1A2230" stroke-width="0.5"/>
+    <rect x="96" y="85" width="12" height="3" fill="#1E8449" opacity="0.3"/>
+
+    <rect x="96" y="90" width="16" height="3" fill="none" stroke="#1A2230" stroke-width="0.5"/>
+    <rect x="96" y="90" width="7" height="3" fill="#D68910" opacity="0.3"/>
+
+    <rect x="96" y="95" width="16" height="3" fill="none" stroke="#1A2230" stroke-width="0.5"/>
+    <rect x="96" y="95" width="16" height="3" fill="#C0392B" opacity="0.15"/>
+
+    <rect x="96" y="100" width="9" height="1.5" fill="#3A4F61" opacity="0.4"/>
+    <rect x="96" y="103" width="12" height="1.5" fill="#3A4F61" opacity="0.3"/>
+
+  </g>
+
+</svg>

--- a/public/icons/launch.svg
+++ b/public/icons/launch.svg
@@ -6,16 +6,22 @@
       <stop offset="100%" stop-color="#080B0F"/>
     </linearGradient>
 
-    <!-- Pipeline flow gradient — accent trace left to right -->
+    <!-- Pipeline flow gradient — left to right -->
     <linearGradient id="l-flow" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#4A8FBF" stop-opacity="0.9"/>
-      <stop offset="100%" stop-color="#4A8FBF" stop-opacity="0.3"/>
+      <stop offset="0%"   stop-color="#4A8FBF" stop-opacity="0.9"/>
+      <stop offset="100%" stop-color="#4A8FBF" stop-opacity="0.25"/>
     </linearGradient>
 
-    <!-- Deployment success gradient -->
+    <!-- Deploy success bar fill -->
     <linearGradient id="l-deploy" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#1E8449" stop-opacity="0.6"/>
+      <stop offset="0%" stop-color="#1E8449" stop-opacity="0.65"/>
       <stop offset="100%" stop-color="#1E8449" stop-opacity="0.15"/>
+    </linearGradient>
+
+    <!-- Secrets vault bg -->
+    <linearGradient id="l-vault" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%"   stop-color="#1A2230"/>
+      <stop offset="100%" stop-color="#0D1117"/>
     </linearGradient>
 
     <clipPath id="l-clip">
@@ -36,131 +42,193 @@
     <!-- ── Header bar ─────────────────────────────────────────── -->
     <rect x="4" y="4" width="112" height="14" fill="#0D1117"/>
     <line x1="4" y1="18" x2="116" y2="18" stroke="#243040" stroke-width="0.75"/>
-    <!-- Status dot — pass green -->
+    <!-- Status dot — pass (deployed) -->
     <rect x="10" y="9" width="4" height="4" fill="#1E8449"/>
     <!-- Header labels -->
-    <rect x="18" y="10" width="22" height="2" fill="#5A7184" opacity="0.6"/>
-    <rect x="44" y="10" width="10" height="2" fill="#3A4F61" opacity="0.5"/>
+    <rect x="18" y="10" width="16" height="2" fill="#5A7184" opacity="0.6"/>
+    <rect x="38" y="10" width="10" height="2" fill="#3A4F61" opacity="0.5"/>
     <!-- Right label -->
-    <rect x="82" y="10" width="28" height="2" fill="#3A4F61" opacity="0.4"/>
+    <rect x="88" y="10" width="22" height="2" fill="#3A4F61" opacity="0.4"/>
 
-    <!-- ── Branch topology — top section ─────────────────────── -->
-    <!-- Main branch line (horizontal spine) -->
-    <line x1="14" y1="36" x2="106" y2="36" stroke="#243040" stroke-width="1"/>
+    <!-- ════════════════════════════════════════════════════════
+         GIT BRANCH TOPOLOGY — top section (rows 18–62)
+         Main branch + PR forks + merge → deploy
+         ════════════════════════════════════════════════════════ -->
 
-    <!-- Branch node — PR #1 (main, passing) -->
-    <rect x="10" y="32" width="8" height="8" fill="none" stroke="#4A8FBF" stroke-width="0.75"/>
-    <rect x="12" y="34" width="4" height="4" fill="#4A8FBF" opacity="0.7"/>
+    <!-- Subtle background grid -->
+    <line x1="4"  y1="30" x2="116" y2="30" stroke="#1A2230" stroke-width="0.5" opacity="0.6"/>
+    <line x1="4"  y1="44" x2="116" y2="44" stroke="#1A2230" stroke-width="0.5" opacity="0.6"/>
+    <line x1="4"  y1="58" x2="116" y2="58" stroke="#1A2230" stroke-width="0.5" opacity="0.6"/>
 
-    <!-- Branch fork down — PR preview -->
-    <line x1="30" y1="36" x2="30" y2="52" stroke="#4A8FBF" stroke-width="0.75" opacity="0.6"/>
-    <rect x="26" y="32" width="8" height="8" fill="none" stroke="#243040" stroke-width="0.75"/>
-    <rect x="28" y="34" width="4" height="4" fill="#5A7184" opacity="0.5"/>
+    <!-- ── Main branch spine ───────────────────────────────── -->
+    <line x1="10" y1="36" x2="106" y2="36" stroke="#243040" stroke-width="0.75"/>
 
-    <!-- Branch fork down — PR preview 2 -->
-    <line x1="50" y1="36" x2="50" y2="52" stroke="#D68910" stroke-width="0.75" opacity="0.5"/>
-    <rect x="46" y="32" width="8" height="8" fill="none" stroke="#D68910" stroke-width="0.75" opacity="0.7"/>
-    <rect x="48" y="34" width="4" height="4" fill="#D68910" opacity="0.4"/>
+    <!-- Commit node 1 — base, merged -->
+    <rect x="8" y="32" width="8" height="8" fill="#131920" stroke="#4A8FBF" stroke-width="0.75"/>
+    <rect x="10" y="34" width="4" height="4" fill="#4A8FBF" opacity="0.8"/>
 
-    <!-- Branch node — merged, deploy -->
-    <rect x="66" y="32" width="8" height="8" fill="none" stroke="#4A8FBF" stroke-width="1"/>
-    <rect x="68" y="34" width="4" height="4" fill="#4A8FBF" opacity="0.9"/>
+    <!-- Commit node 2 — checkpoint -->
+    <rect x="26" y="32" width="8" height="8" fill="#131920" stroke="#243040" stroke-width="0.75"/>
+    <rect x="28" y="34" width="4" height="4" fill="#5A7184" opacity="0.4"/>
 
-    <!-- Arrow to deploy -->
-    <polyline points="74,36 84,36" stroke="url(#l-flow)" stroke-width="1" fill="none"/>
-    <polygon points="84,33 90,36 84,39" fill="#4A8FBF" opacity="0.7"/>
+    <!-- PR branch fork down from node 2 -->
+    <line x1="30" y1="40" x2="30" y2="50" stroke="#4A8FBF" stroke-width="0.75" opacity="0.6"/>
 
-    <!-- Deploy target node -->
-    <rect x="92" y="30" width="18" height="12" fill="none" stroke="#4A8FBF" stroke-width="0.75" opacity="0.8"/>
-    <rect x="94" y="32" width="14" height="3" fill="#4A8FBF" opacity="0.2"/>
-    <line x1="92" y1="35" x2="110" y2="35" stroke="#243040" stroke-width="0.5"/>
-    <rect x="94" y="37" width="8" height="1.5" fill="#1E8449" opacity="0.5"/>
-    <rect x="94" y="39.5" width="5" height="1.5" fill="#3A4F61" opacity="0.4"/>
+    <!-- Commit node 3 — another checkpoint -->
+    <rect x="44" y="32" width="8" height="8" fill="#131920" stroke="#D68910" stroke-width="0.75" opacity="0.7"/>
+    <rect x="46" y="34" width="4" height="4" fill="#D68910" opacity="0.4"/>
 
-    <!-- PR preview environments — child nodes -->
-    <!-- Preview env 1 -->
-    <rect x="22" y="52" width="16" height="10" fill="none" stroke="#4A8FBF" stroke-width="0.5" opacity="0.5"/>
-    <rect x="24" y="54" width="10" height="1.5" fill="#4A8FBF" opacity="0.3"/>
-    <rect x="24" y="57" width="6" height="1.5" fill="#1E8449" opacity="0.4"/>
-    <rect x="31" y="57" width="5" height="1.5" fill="#3A4F61" opacity="0.3"/>
+    <!-- PR branch fork down from node 3 -->
+    <line x1="48" y1="40" x2="48" y2="50" stroke="#D68910" stroke-width="0.75" opacity="0.5"/>
 
-    <!-- Preview env 2 -->
-    <rect x="42" y="52" width="16" height="10" fill="none" stroke="#D68910" stroke-width="0.5" opacity="0.5"/>
-    <rect x="44" y="54" width="10" height="1.5" fill="#D68910" opacity="0.3"/>
-    <rect x="44" y="57" width="6" height="1.5" fill="#D68910" opacity="0.4"/>
-    <rect x="51" y="57" width="5" height="1.5" fill="#3A4F61" opacity="0.3"/>
+    <!-- Commit node 4 — merge point -->
+    <rect x="62" y="32" width="8" height="8" fill="#131920" stroke="#4A8FBF" stroke-width="1"/>
+    <rect x="64" y="34" width="4" height="4" fill="#4A8FBF" opacity="0.9"/>
 
-    <!-- ── Pipeline stages — middle section ──────────────────── -->
-    <line x1="4" y1="70" x2="116" y2="70" stroke="#1A2230" stroke-width="0.5"/>
+    <!-- Arrow: merge → deploy node -->
+    <line x1="70" y1="36" x2="80" y2="36" stroke="url(#l-flow)" stroke-width="1"/>
+    <!-- Arrow head (sharp polygon) -->
+    <polygon points="80,33 87,36 80,39" fill="#4A8FBF" opacity="0.75"/>
 
-    <!-- Stage labels row -->
-    <rect x="4" y="70" width="112" height="10" fill="#131920"/>
-    <line x1="4" y1="80" x2="116" y2="80" stroke="#1A2230" stroke-width="0.5"/>
+    <!-- Deploy target node — prominent -->
+    <rect x="88" y="29" width="24" height="15" fill="#131920" stroke="#4A8FBF" stroke-width="0.75" opacity="0.85"/>
+    <rect x="89" y="30" width="22" height="5" fill="#1A2230"/>
+    <rect x="91" y="31" width="6"  height="2" fill="#4A8FBF" opacity="0.5"/>
+    <rect x="99" y="31" width="9"  height="2" fill="#3A4F61" opacity="0.3"/>
+    <line x1="88" y1="35" x2="112" y2="35" stroke="#243040" stroke-width="0.5"/>
+    <rect x="91" y="37" width="3"  height="3" fill="#1E8449" opacity="0.7"/>
+    <rect x="96" y="37.5" width="10" height="1.5" fill="#5A7184" opacity="0.3"/>
+    <rect x="91" y="41" width="16" height="1.5" fill="#3A4F61" opacity="0.25"/>
 
-    <!-- Stage column separators -->
-    <line x1="32" y1="70" x2="32" y2="116" stroke="#1A2230" stroke-width="0.5"/>
-    <line x1="64" y1="70" x2="64" y2="116" stroke="#1A2230" stroke-width="0.5"/>
-    <line x1="96" y1="70" x2="96" y2="116" stroke="#1A2230" stroke-width="0.5"/>
+    <!-- ── Preview environment cards (below branch forks) ─────── -->
 
-    <!-- Stage header labels -->
-    <rect x="8" y="73.5" width="14" height="1.5" fill="#4A8FBF" opacity="0.4"/>
-    <rect x="36" y="73.5" width="16" height="1.5" fill="#3A4F61" opacity="0.4"/>
-    <rect x="68" y="73.5" width="14" height="1.5" fill="#3A4F61" opacity="0.4"/>
-    <rect x="100" y="73.5" width="12" height="1.5" fill="#3A4F61" opacity="0.4"/>
+    <!-- PR #1 env card — passing -->
+    <rect x="20" y="50" width="20" height="12" fill="none" stroke="#4A8FBF" stroke-width="0.5" opacity="0.55"/>
+    <rect x="21" y="51" width="18" height="3" fill="#131920"/>
+    <rect x="22" y="52" width="8"  height="1.5" fill="#4A8FBF" opacity="0.35"/>
+    <rect x="22" y="55.5" width="3"  height="3" fill="#1E8449" opacity="0.6"/>
+    <rect x="26" y="56" width="10" height="1.5" fill="#3A4F61" opacity="0.3"/>
+    <rect x="22" y="59" width="14" height="1.5" fill="#3A4F61" opacity="0.2"/>
+
+    <!-- PR #2 env card — failing test -->
+    <rect x="40" y="50" width="20" height="12" fill="none" stroke="#D68910" stroke-width="0.5" opacity="0.55"/>
+    <rect x="41" y="51" width="18" height="3" fill="#131920"/>
+    <rect x="42" y="52" width="8"  height="1.5" fill="#D68910" opacity="0.35"/>
+    <rect x="42" y="55.5" width="3"  height="3" fill="#D68910" opacity="0.5"/>
+    <rect x="46" y="56" width="10" height="1.5" fill="#3A4F61" opacity="0.3"/>
+    <rect x="42" y="59" width="12" height="1.5" fill="#3A4F61" opacity="0.2"/>
+
+    <!-- ════════════════════════════════════════════════════════
+         PIPELINE STAGES — middle band (rows 62–90)
+         ════════════════════════════════════════════════════════ -->
+
+    <line x1="4" y1="62" x2="116" y2="62" stroke="#243040" stroke-width="0.75"/>
+    <rect x="4" y="62" width="112" height="10" fill="#131920"/>
+    <line x1="4" y1="72" x2="116" y2="72" stroke="#1A2230" stroke-width="0.75"/>
+
+    <!-- Column separators for stages -->
+    <line x1="32"  y1="62" x2="32"  y2="92" stroke="#1A2230" stroke-width="0.5"/>
+    <line x1="60"  y1="62" x2="60"  y2="92" stroke="#1A2230" stroke-width="0.5"/>
+    <line x1="88"  y1="62" x2="88"  y2="92" stroke="#1A2230" stroke-width="0.5"/>
+
+    <!-- Stage header text blocks -->
+    <rect x="8"  y="65.5" width="14" height="1.5" fill="#4A8FBF" opacity="0.45"/>
+    <rect x="36" y="65.5" width="16" height="1.5" fill="#3A4F61" opacity="0.4"/>
+    <rect x="64" y="65.5" width="12" height="1.5" fill="#3A4F61" opacity="0.4"/>
+    <rect x="92" y="65.5" width="14" height="1.5" fill="#3A4F61" opacity="0.4"/>
 
     <!-- Stage 1 — SOURCE: pass -->
-    <rect x="8" y="83" width="20" height="6" fill="url(#l-deploy)" opacity="0.8"/>
-    <rect x="8" y="83" width="20" height="6" fill="none" stroke="#1E8449" stroke-width="0.5" opacity="0.6"/>
-    <rect x="10" y="85" width="6" height="1.5" fill="#1E8449" opacity="0.5"/>
+    <rect x="8"  y="75" width="20" height="7" fill="url(#l-deploy)" opacity="0.85"/>
+    <rect x="8"  y="75" width="20" height="7" fill="none" stroke="#1E8449" stroke-width="0.5" opacity="0.6"/>
+    <rect x="10" y="77" width="5"  height="1.5" fill="#1E8449" opacity="0.5"/>
 
     <!-- Stage 2 — BUILD: pass -->
-    <rect x="36" y="83" width="24" height="6" fill="url(#l-deploy)" opacity="0.6"/>
-    <rect x="36" y="83" width="24" height="6" fill="none" stroke="#1E8449" stroke-width="0.5" opacity="0.5"/>
-    <rect x="38" y="85" width="10" height="1.5" fill="#1E8449" opacity="0.4"/>
+    <rect x="36" y="75" width="20" height="7" fill="url(#l-deploy)" opacity="0.65"/>
+    <rect x="36" y="75" width="20" height="7" fill="none" stroke="#1E8449" stroke-width="0.5" opacity="0.5"/>
+    <rect x="38" y="77" width="10" height="1.5" fill="#1E8449" opacity="0.4"/>
 
     <!-- Stage 3 — TEST: warning -->
-    <rect x="68" y="83" width="20" height="6" fill="#D68910" opacity="0.1"/>
-    <rect x="68" y="83" width="20" height="6" fill="none" stroke="#D68910" stroke-width="0.5" opacity="0.5"/>
-    <rect x="70" y="85" width="8" height="1.5" fill="#D68910" opacity="0.4"/>
+    <rect x="64" y="75" width="20" height="7" fill="#D68910" opacity="0.08"/>
+    <rect x="64" y="75" width="20" height="7" fill="none" stroke="#D68910" stroke-width="0.5" opacity="0.5"/>
+    <rect x="66" y="77" width="8"  height="1.5" fill="#D68910" opacity="0.4"/>
 
-    <!-- Stage 4 — DEPLOY: blocked indicator -->
-    <rect x="100" y="83" width="12" height="6" fill="none" stroke="#243040" stroke-width="0.5"/>
-    <rect x="102" y="85" width="6" height="1.5" fill="#3A4F61" opacity="0.3"/>
+    <!-- Stage 4 — DEPLOY: pending -->
+    <rect x="92" y="75" width="20" height="7" fill="none" stroke="#243040" stroke-width="0.5"/>
+    <rect x="94" y="77" width="10" height="1.5" fill="#3A4F61" opacity="0.3"/>
 
     <!-- Flow arrows between stages -->
-    <polyline points="28,86 34,86" stroke="#1E8449" stroke-width="0.75" fill="none" opacity="0.6"/>
-    <polyline points="60,86 66,86" stroke="#D68910" stroke-width="0.75" fill="none" opacity="0.5"/>
-    <polyline points="88,86 98,86" stroke="#3A4F61" stroke-width="0.75" fill="none" opacity="0.4"/>
+    <line x1="28" y1="78.5" x2="36" y2="78.5" stroke="#1E8449" stroke-width="0.75" opacity="0.5"/>
+    <polyline points="33,76.5 36,78.5 33,80.5" stroke="#1E8449" stroke-width="0.5" fill="none" opacity="0.5"/>
 
-    <!-- ── Secrets management panel — bottom ─────────────────── -->
-    <line x1="4" y1="96" x2="116" y2="96" stroke="#243040" stroke-width="0.75"/>
-    <rect x="4" y="96" width="112" height="20" fill="#0D1117"/>
+    <line x1="56" y1="78.5" x2="64" y2="78.5" stroke="#D68910" stroke-width="0.75" opacity="0.4"/>
+    <polyline points="61,76.5 64,78.5 61,80.5" stroke="#D68910" stroke-width="0.5" fill="none" opacity="0.4"/>
 
-    <!-- Secrets header -->
-    <rect x="10" y="100" width="16" height="1.5" fill="#4A8FBF" opacity="0.45"/>
-    <!-- Lock icon simulation — small rectangle with bracket -->
-    <rect x="100" y="98" width="6" height="8" fill="none" stroke="#4A8FBF" stroke-width="0.75" opacity="0.5"/>
-    <polyline points="101,98 101,96 105,96 105,98" stroke="#4A8FBF" stroke-width="0.75" fill="none" opacity="0.5"/>
+    <line x1="84" y1="78.5" x2="92" y2="78.5" stroke="#243040" stroke-width="0.75" opacity="0.5"/>
+    <polyline points="89,76.5 92,78.5 89,80.5" stroke="#243040" stroke-width="0.5" fill="none" opacity="0.5"/>
 
-    <!-- Secret rows — redacted keys -->
-    <rect x="10" y="104" width="8" height="1.5" fill="#3A4F61" opacity="0.5"/>
-    <rect x="22" y="104" width="30" height="1.5" fill="#1A2230" opacity="0.8"/>
-    <rect x="22" y="104" width="30" height="1.5" fill="none" stroke="#3A4F61" stroke-width="0.3" opacity="0.5"/>
-    <rect x="56" y="104" width="6" height="1.5" fill="#1E8449" opacity="0.4"/>
+    <line x1="4" y1="92" x2="116" y2="92" stroke="#243040" stroke-width="0.75"/>
 
-    <rect x="10" y="108" width="8" height="1.5" fill="#3A4F61" opacity="0.4"/>
-    <rect x="22" y="108" width="24" height="1.5" fill="#1A2230" opacity="0.8"/>
-    <rect x="22" y="108" width="24" height="1.5" fill="none" stroke="#3A4F61" stroke-width="0.3" opacity="0.5"/>
-    <rect x="50" y="108" width="6" height="1.5" fill="#1E8449" opacity="0.4"/>
+    <!-- ════════════════════════════════════════════════════════
+         SECRETS MANAGEMENT PANEL — bottom (rows 92–116)
+         ════════════════════════════════════════════════════════ -->
 
-    <rect x="10" y="112" width="8" height="1.5" fill="#3A4F61" opacity="0.3"/>
-    <rect x="22" y="112" width="36" height="1.5" fill="#1A2230" opacity="0.8"/>
-    <rect x="22" y="112" width="36" height="1.5" fill="none" stroke="#3A4F61" stroke-width="0.3" opacity="0.4"/>
-    <rect x="62" y="112" width="6" height="1.5" fill="#D68910" opacity="0.3"/>
+    <rect x="4" y="92" width="112" height="24" fill="#0D1117"/>
+
+    <!-- Vault header label -->
+    <rect x="10" y="96" width="22" height="2" fill="#4A8FBF" opacity="0.45"/>
+    <line x1="10" y1="96" x2="10" y2="98" stroke="#4A8FBF" stroke-width="1.5" opacity="0.75"/>
+
+    <!-- Lock icon — angular, no rounded corners -->
+    <!-- Shackle (two vertical lines + top crossbar) -->
+    <line x1="101" y1="95" x2="101" y2="93" stroke="#243040" stroke-width="0.75" opacity="0.8"/>
+    <line x1="107" y1="95" x2="107" y2="93" stroke="#243040" stroke-width="0.75" opacity="0.8"/>
+    <line x1="101" y1="93" x2="107" y2="93" stroke="#243040" stroke-width="0.75" opacity="0.8"/>
+    <!-- Body -->
+    <rect x="99" y="95" width="10" height="8" fill="none" stroke="#4A8FBF" stroke-width="0.75" opacity="0.55"/>
+    <rect x="101" y="97" width="6"  height="4" fill="#4A8FBF" opacity="0.1"/>
+    <rect x="103" y="98" width="2"  height="2" fill="#4A8FBF" opacity="0.5"/>
+
+    <!-- Secret rows — key = ██████ [status] -->
+    <!-- Row 1 -->
+    <rect x="10" y="101" width="12" height="1.5" fill="#5A7184" opacity="0.5"/>
+    <line x1="24" y1="101.75" x2="26" y2="101.75" stroke="#3A4F61" stroke-width="1" opacity="0.5"/>
+    <!-- Masked value blocks -->
+    <rect x="28" y="101" width="4"  height="1.5" fill="#4A8FBF" opacity="0.4"/>
+    <rect x="33" y="101" width="4"  height="1.5" fill="#4A8FBF" opacity="0.3"/>
+    <rect x="38" y="101" width="4"  height="1.5" fill="#4A8FBF" opacity="0.22"/>
+    <rect x="43" y="101" width="4"  height="1.5" fill="#4A8FBF" opacity="0.15"/>
+    <rect x="48" y="101" width="4"  height="1.5" fill="#4A8FBF" opacity="0.1"/>
+    <!-- Status -->
+    <rect x="56" y="100.5" width="5" height="2.5" fill="#1E8449" opacity="0.4"/>
+
+    <!-- Row 2 -->
+    <rect x="10" y="106" width="16" height="1.5" fill="#5A7184" opacity="0.4"/>
+    <line x1="28" y1="106.75" x2="30" y2="106.75" stroke="#3A4F61" stroke-width="1" opacity="0.4"/>
+    <rect x="32" y="106" width="4"  height="1.5" fill="#2D5A7A" opacity="0.5"/>
+    <rect x="37" y="106" width="4"  height="1.5" fill="#2D5A7A" opacity="0.4"/>
+    <rect x="42" y="106" width="4"  height="1.5" fill="#2D5A7A" opacity="0.3"/>
+    <rect x="47" y="106" width="4"  height="1.5" fill="#2D5A7A" opacity="0.2"/>
+    <rect x="56" y="105.5" width="5" height="2.5" fill="#1E8449" opacity="0.35"/>
+
+    <!-- Row 3 — warning: env var not configured -->
+    <rect x="10" y="111" width="10" height="1.5" fill="#D68910" opacity="0.55"/>
+    <line x1="22" y1="111.75" x2="24" y2="111.75" stroke="#3A4F61" stroke-width="1" opacity="0.4"/>
+    <!-- Warning indicator -->
+    <rect x="26" y="110.5" width="5" height="5" fill="none" stroke="#D68910" stroke-width="0.5" opacity="0.7"/>
+    <rect x="27.5" y="112" width="2" height="2" fill="#D68910" opacity="0.5"/>
+    <rect x="34" y="111" width="18" height="1.5" fill="#3A4F61" opacity="0.25"/>
+    <rect x="56" y="110.5" width="5" height="2.5" fill="#D68910" opacity="0.25"/>
+
+    <!-- Divider above footer -->
+    <line x1="4" y1="114" x2="116" y2="114" stroke="#1A2230" stroke-width="0.5"/>
+    <!-- Footer summary blocks -->
+    <rect x="10"  y="115.5" width="12" height="1" fill="#3A4F61" opacity="0.4"/>
+    <rect x="26"  y="115.5" width="6"  height="1" fill="#4A8FBF" opacity="0.3"/>
+    <rect x="80"  y="115.5" width="30" height="1" fill="#3A4F61" opacity="0.3"/>
 
   </g>
 
-  <!-- ── Outer accent corner — top right ────────────────────── -->
+  <!-- ── Outer accent corner — top right (redrawn over clip) ── -->
   <polyline points="96,4 112,4 112,20" stroke="#4A8FBF" stroke-width="1" opacity="0.6"/>
 
 </svg>

--- a/public/icons/launch.svg
+++ b/public/icons/launch.svg
@@ -1,0 +1,166 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" width="120" height="120" fill="none">
+  <defs>
+    <!-- Background panel gradient -->
+    <linearGradient id="l-bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0D1117"/>
+      <stop offset="100%" stop-color="#080B0F"/>
+    </linearGradient>
+
+    <!-- Pipeline flow gradient — accent trace left to right -->
+    <linearGradient id="l-flow" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#4A8FBF" stop-opacity="0.9"/>
+      <stop offset="100%" stop-color="#4A8FBF" stop-opacity="0.3"/>
+    </linearGradient>
+
+    <!-- Deployment success gradient -->
+    <linearGradient id="l-deploy" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#1E8449" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#1E8449" stop-opacity="0.15"/>
+    </linearGradient>
+
+    <clipPath id="l-clip">
+      <rect x="4" y="4" width="112" height="112"/>
+    </clipPath>
+  </defs>
+
+  <!-- ── Outer frame ─────────────────────────────────────────── -->
+  <rect x="4" y="4" width="112" height="112" fill="url(#l-bg)" stroke="#243040" stroke-width="1"/>
+
+  <!-- Corner cut mark — top right (accent) -->
+  <polyline points="96,4 112,4 112,20" stroke="#4A8FBF" stroke-width="1" opacity="0.6"/>
+  <!-- Corner mark — bottom left (dim) -->
+  <polyline points="24,116 4,116 4,100" stroke="#243040" stroke-width="1" opacity="0.5"/>
+
+  <g clip-path="url(#l-clip)">
+
+    <!-- ── Header bar ─────────────────────────────────────────── -->
+    <rect x="4" y="4" width="112" height="14" fill="#0D1117"/>
+    <line x1="4" y1="18" x2="116" y2="18" stroke="#243040" stroke-width="0.75"/>
+    <!-- Status dot — pass green -->
+    <rect x="10" y="9" width="4" height="4" fill="#1E8449"/>
+    <!-- Header labels -->
+    <rect x="18" y="10" width="22" height="2" fill="#5A7184" opacity="0.6"/>
+    <rect x="44" y="10" width="10" height="2" fill="#3A4F61" opacity="0.5"/>
+    <!-- Right label -->
+    <rect x="82" y="10" width="28" height="2" fill="#3A4F61" opacity="0.4"/>
+
+    <!-- ── Branch topology — top section ─────────────────────── -->
+    <!-- Main branch line (horizontal spine) -->
+    <line x1="14" y1="36" x2="106" y2="36" stroke="#243040" stroke-width="1"/>
+
+    <!-- Branch node — PR #1 (main, passing) -->
+    <rect x="10" y="32" width="8" height="8" fill="none" stroke="#4A8FBF" stroke-width="0.75"/>
+    <rect x="12" y="34" width="4" height="4" fill="#4A8FBF" opacity="0.7"/>
+
+    <!-- Branch fork down — PR preview -->
+    <line x1="30" y1="36" x2="30" y2="52" stroke="#4A8FBF" stroke-width="0.75" opacity="0.6"/>
+    <rect x="26" y="32" width="8" height="8" fill="none" stroke="#243040" stroke-width="0.75"/>
+    <rect x="28" y="34" width="4" height="4" fill="#5A7184" opacity="0.5"/>
+
+    <!-- Branch fork down — PR preview 2 -->
+    <line x1="50" y1="36" x2="50" y2="52" stroke="#D68910" stroke-width="0.75" opacity="0.5"/>
+    <rect x="46" y="32" width="8" height="8" fill="none" stroke="#D68910" stroke-width="0.75" opacity="0.7"/>
+    <rect x="48" y="34" width="4" height="4" fill="#D68910" opacity="0.4"/>
+
+    <!-- Branch node — merged, deploy -->
+    <rect x="66" y="32" width="8" height="8" fill="none" stroke="#4A8FBF" stroke-width="1"/>
+    <rect x="68" y="34" width="4" height="4" fill="#4A8FBF" opacity="0.9"/>
+
+    <!-- Arrow to deploy -->
+    <polyline points="74,36 84,36" stroke="url(#l-flow)" stroke-width="1" fill="none"/>
+    <polygon points="84,33 90,36 84,39" fill="#4A8FBF" opacity="0.7"/>
+
+    <!-- Deploy target node -->
+    <rect x="92" y="30" width="18" height="12" fill="none" stroke="#4A8FBF" stroke-width="0.75" opacity="0.8"/>
+    <rect x="94" y="32" width="14" height="3" fill="#4A8FBF" opacity="0.2"/>
+    <line x1="92" y1="35" x2="110" y2="35" stroke="#243040" stroke-width="0.5"/>
+    <rect x="94" y="37" width="8" height="1.5" fill="#1E8449" opacity="0.5"/>
+    <rect x="94" y="39.5" width="5" height="1.5" fill="#3A4F61" opacity="0.4"/>
+
+    <!-- PR preview environments — child nodes -->
+    <!-- Preview env 1 -->
+    <rect x="22" y="52" width="16" height="10" fill="none" stroke="#4A8FBF" stroke-width="0.5" opacity="0.5"/>
+    <rect x="24" y="54" width="10" height="1.5" fill="#4A8FBF" opacity="0.3"/>
+    <rect x="24" y="57" width="6" height="1.5" fill="#1E8449" opacity="0.4"/>
+    <rect x="31" y="57" width="5" height="1.5" fill="#3A4F61" opacity="0.3"/>
+
+    <!-- Preview env 2 -->
+    <rect x="42" y="52" width="16" height="10" fill="none" stroke="#D68910" stroke-width="0.5" opacity="0.5"/>
+    <rect x="44" y="54" width="10" height="1.5" fill="#D68910" opacity="0.3"/>
+    <rect x="44" y="57" width="6" height="1.5" fill="#D68910" opacity="0.4"/>
+    <rect x="51" y="57" width="5" height="1.5" fill="#3A4F61" opacity="0.3"/>
+
+    <!-- ── Pipeline stages — middle section ──────────────────── -->
+    <line x1="4" y1="70" x2="116" y2="70" stroke="#1A2230" stroke-width="0.5"/>
+
+    <!-- Stage labels row -->
+    <rect x="4" y="70" width="112" height="10" fill="#131920"/>
+    <line x1="4" y1="80" x2="116" y2="80" stroke="#1A2230" stroke-width="0.5"/>
+
+    <!-- Stage column separators -->
+    <line x1="32" y1="70" x2="32" y2="116" stroke="#1A2230" stroke-width="0.5"/>
+    <line x1="64" y1="70" x2="64" y2="116" stroke="#1A2230" stroke-width="0.5"/>
+    <line x1="96" y1="70" x2="96" y2="116" stroke="#1A2230" stroke-width="0.5"/>
+
+    <!-- Stage header labels -->
+    <rect x="8" y="73.5" width="14" height="1.5" fill="#4A8FBF" opacity="0.4"/>
+    <rect x="36" y="73.5" width="16" height="1.5" fill="#3A4F61" opacity="0.4"/>
+    <rect x="68" y="73.5" width="14" height="1.5" fill="#3A4F61" opacity="0.4"/>
+    <rect x="100" y="73.5" width="12" height="1.5" fill="#3A4F61" opacity="0.4"/>
+
+    <!-- Stage 1 — SOURCE: pass -->
+    <rect x="8" y="83" width="20" height="6" fill="url(#l-deploy)" opacity="0.8"/>
+    <rect x="8" y="83" width="20" height="6" fill="none" stroke="#1E8449" stroke-width="0.5" opacity="0.6"/>
+    <rect x="10" y="85" width="6" height="1.5" fill="#1E8449" opacity="0.5"/>
+
+    <!-- Stage 2 — BUILD: pass -->
+    <rect x="36" y="83" width="24" height="6" fill="url(#l-deploy)" opacity="0.6"/>
+    <rect x="36" y="83" width="24" height="6" fill="none" stroke="#1E8449" stroke-width="0.5" opacity="0.5"/>
+    <rect x="38" y="85" width="10" height="1.5" fill="#1E8449" opacity="0.4"/>
+
+    <!-- Stage 3 — TEST: warning -->
+    <rect x="68" y="83" width="20" height="6" fill="#D68910" opacity="0.1"/>
+    <rect x="68" y="83" width="20" height="6" fill="none" stroke="#D68910" stroke-width="0.5" opacity="0.5"/>
+    <rect x="70" y="85" width="8" height="1.5" fill="#D68910" opacity="0.4"/>
+
+    <!-- Stage 4 — DEPLOY: blocked indicator -->
+    <rect x="100" y="83" width="12" height="6" fill="none" stroke="#243040" stroke-width="0.5"/>
+    <rect x="102" y="85" width="6" height="1.5" fill="#3A4F61" opacity="0.3"/>
+
+    <!-- Flow arrows between stages -->
+    <polyline points="28,86 34,86" stroke="#1E8449" stroke-width="0.75" fill="none" opacity="0.6"/>
+    <polyline points="60,86 66,86" stroke="#D68910" stroke-width="0.75" fill="none" opacity="0.5"/>
+    <polyline points="88,86 98,86" stroke="#3A4F61" stroke-width="0.75" fill="none" opacity="0.4"/>
+
+    <!-- ── Secrets management panel — bottom ─────────────────── -->
+    <line x1="4" y1="96" x2="116" y2="96" stroke="#243040" stroke-width="0.75"/>
+    <rect x="4" y="96" width="112" height="20" fill="#0D1117"/>
+
+    <!-- Secrets header -->
+    <rect x="10" y="100" width="16" height="1.5" fill="#4A8FBF" opacity="0.45"/>
+    <!-- Lock icon simulation — small rectangle with bracket -->
+    <rect x="100" y="98" width="6" height="8" fill="none" stroke="#4A8FBF" stroke-width="0.75" opacity="0.5"/>
+    <polyline points="101,98 101,96 105,96 105,98" stroke="#4A8FBF" stroke-width="0.75" fill="none" opacity="0.5"/>
+
+    <!-- Secret rows — redacted keys -->
+    <rect x="10" y="104" width="8" height="1.5" fill="#3A4F61" opacity="0.5"/>
+    <rect x="22" y="104" width="30" height="1.5" fill="#1A2230" opacity="0.8"/>
+    <rect x="22" y="104" width="30" height="1.5" fill="none" stroke="#3A4F61" stroke-width="0.3" opacity="0.5"/>
+    <rect x="56" y="104" width="6" height="1.5" fill="#1E8449" opacity="0.4"/>
+
+    <rect x="10" y="108" width="8" height="1.5" fill="#3A4F61" opacity="0.4"/>
+    <rect x="22" y="108" width="24" height="1.5" fill="#1A2230" opacity="0.8"/>
+    <rect x="22" y="108" width="24" height="1.5" fill="none" stroke="#3A4F61" stroke-width="0.3" opacity="0.5"/>
+    <rect x="50" y="108" width="6" height="1.5" fill="#1E8449" opacity="0.4"/>
+
+    <rect x="10" y="112" width="8" height="1.5" fill="#3A4F61" opacity="0.3"/>
+    <rect x="22" y="112" width="36" height="1.5" fill="#1A2230" opacity="0.8"/>
+    <rect x="22" y="112" width="36" height="1.5" fill="none" stroke="#3A4F61" stroke-width="0.3" opacity="0.4"/>
+    <rect x="62" y="112" width="6" height="1.5" fill="#D68910" opacity="0.3"/>
+
+  </g>
+
+  <!-- ── Outer accent corner — top right ────────────────────── -->
+  <polyline points="96,4 112,4 112,20" stroke="#4A8FBF" stroke-width="1" opacity="0.6"/>
+
+</svg>

--- a/public/icons/sentinel.svg
+++ b/public/icons/sentinel.svg
@@ -8,15 +8,22 @@
 
     <!-- Sweep arc gradient — accent fading to transparent -->
     <linearGradient id="s-sweep" x1="1" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#4A8FBF" stop-opacity="0.55"/>
+      <stop offset="0%" stop-color="#4A8FBF" stop-opacity="0.45"/>
       <stop offset="100%" stop-color="#4A8FBF" stop-opacity="0"/>
     </linearGradient>
 
-    <!-- Signal trace gradient -->
+    <!-- Signal trace gradient — anomaly highlight -->
     <linearGradient id="s-trace" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#4A8FBF" stop-opacity="0"/>
-      <stop offset="40%" stop-color="#4A8FBF" stop-opacity="0.7"/>
+      <stop offset="0%"   stop-color="#4A8FBF" stop-opacity="0"/>
+      <stop offset="35%"  stop-color="#4A8FBF" stop-opacity="0.7"/>
+      <stop offset="65%"  stop-color="#4A8FBF" stop-opacity="0.9"/>
       <stop offset="100%" stop-color="#4A8FBF" stop-opacity="0.15"/>
+    </linearGradient>
+
+    <!-- Check row alt background -->
+    <linearGradient id="s-row-crit" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%"   stop-color="#C0392B" stop-opacity="0.12"/>
+      <stop offset="100%" stop-color="#C0392B" stop-opacity="0"/>
     </linearGradient>
 
     <!-- Clip to icon bounds -->
@@ -28,116 +35,182 @@
   <!-- ── Outer frame ─────────────────────────────────────────── -->
   <rect x="4" y="4" width="112" height="112" fill="url(#s-bg)" stroke="#243040" stroke-width="1"/>
 
-  <!-- Corner cut mark — top right -->
+  <!-- Corner cut mark — top right (accent) -->
   <polyline points="96,4 112,4 112,20" stroke="#4A8FBF" stroke-width="1" opacity="0.6"/>
-  <!-- Corner mark — bottom left -->
+  <!-- Corner mark — bottom left (dim) -->
   <polyline points="24,116 4,116 4,100" stroke="#243040" stroke-width="1" opacity="0.5"/>
 
   <!-- ── Inner scan field (clipped) ─────────────────────────── -->
   <g clip-path="url(#s-clip)">
 
-    <!-- Background grid — horizontal scan lines -->
-    <line x1="4"  y1="28" x2="116" y2="28" stroke="#1A2230" stroke-width="0.5"/>
-    <line x1="4"  y1="44" x2="116" y2="44" stroke="#1A2230" stroke-width="0.5"/>
-    <line x1="4"  y1="60" x2="116" y2="60" stroke="#1A2230" stroke-width="0.5"/>
-    <line x1="4"  y1="76" x2="116" y2="76" stroke="#1A2230" stroke-width="0.5"/>
-    <line x1="4"  y1="92" x2="116" y2="92" stroke="#1A2230" stroke-width="0.5"/>
-
-    <!-- Background grid — vertical divisions -->
-    <line x1="26"  y1="4" x2="26"  y2="116" stroke="#1A2230" stroke-width="0.5"/>
-    <line x1="48"  y1="4" x2="48"  y2="116" stroke="#1A2230" stroke-width="0.5"/>
-    <line x1="70"  y1="4" x2="70"  y2="116" stroke="#1A2230" stroke-width="0.5"/>
-    <line x1="92"  y1="4" x2="92"  y2="116" stroke="#1A2230" stroke-width="0.5"/>
-
-    <!-- ── Radar sweep quadrant (origin: bottom-left corner of scan field) ── -->
-    <!-- Origin at (4, 116) — sweep covers upper-right quadrant -->
-
-    <!-- Sweep fill wedge — quarter circle arc -->
-    <!-- Drawn as a pie slice from origin -->
-    <path
-      d="M 14 106
-         L 14 22
-         A 84 84 0 0 1 98 106
-         Z"
-      fill="url(#s-sweep)"
-      opacity="0.18"
-    />
-
-    <!-- Sweep leading edge line -->
-    <line x1="14" y1="106" x2="80" y2="28"
-      stroke="#4A8FBF" stroke-width="1" opacity="0.55"/>
-
-    <!-- Concentric range rings — quarter arcs from origin (14,106) -->
-    <path d="M 14 78  A 28 28 0 0 1 42 106" stroke="#243040" stroke-width="0.75" fill="none"/>
-    <path d="M 14 50  A 56 56 0 0 1 70 106" stroke="#243040" stroke-width="0.75" fill="none"/>
-    <path d="M 14 22  A 84 84 0 0 1 98 106" stroke="#243040" stroke-width="0.75" fill="none"/>
-
-    <!-- Range ring accent ticks -->
-    <line x1="14" y1="78" x2="18" y2="78" stroke="#4A8FBF" stroke-width="0.75" opacity="0.5"/>
-    <line x1="14" y1="50" x2="18" y2="50" stroke="#4A8FBF" stroke-width="0.75" opacity="0.5"/>
-    <line x1="42" y1="106" x2="42" y2="102" stroke="#4A8FBF" stroke-width="0.75" opacity="0.5"/>
-    <line x1="70" y1="106" x2="70" y2="102" stroke="#4A8FBF" stroke-width="0.75" opacity="0.5"/>
-
-    <!-- ── Signal trace / waveform — horizontal ────────────────── -->
-    <!-- Drawn along y=60, showing an anomaly spike -->
-    <polyline
-      points="4,60 20,60 26,60 30,54 34,67 38,57 42,60 54,60 58,60 60,44 62,60 66,60 92,60 116,60"
-      stroke="url(#s-trace)" stroke-width="1.25" fill="none"
-    />
-
-    <!-- Spike highlight — the anomaly peak -->
-    <line x1="60" y1="46" x2="60" y2="58" stroke="#4A8FBF" stroke-width="1" opacity="0.9"/>
-    <!-- Anomaly marker — small square dot -->
-    <rect x="58.5" y="43" width="3" height="3" fill="#4A8FBF" opacity="0.9"/>
-
-    <!-- ── Threat classification markers ───────────────────────── -->
-
-    <!-- Target 1 — critical, near sweep origin area -->
-    <rect x="38" y="82" width="4" height="4" fill="none" stroke="#C0392B" stroke-width="1"/>
-    <!-- Cross-hair lines for target 1 -->
-    <line x1="40" y1="79" x2="40" y2="81" stroke="#C0392B" stroke-width="0.75" opacity="0.8"/>
-    <line x1="43" y1="84" x2="45" y2="84" stroke="#C0392B" stroke-width="0.75" opacity="0.8"/>
-    <!-- Blinking pulse ring -->
-    <rect x="35" y="79" width="10" height="10" fill="none" stroke="#C0392B" stroke-width="0.5" opacity="0.4"/>
-
-    <!-- Target 2 — warning, mid-range -->
-    <rect x="64" y="50" width="4" height="4" fill="none" stroke="#D68910" stroke-width="1"/>
-    <line x1="66" y1="47" x2="66" y2="49" stroke="#D68910" stroke-width="0.75" opacity="0.8"/>
-    <line x1="69" y1="52" x2="71" y2="52" stroke="#D68910" stroke-width="0.75" opacity="0.8"/>
-
-    <!-- Target 3 — pass, far range -->
-    <rect x="84" y="76" width="3" height="3" fill="none" stroke="#1E8449" stroke-width="0.75"/>
-
     <!-- ── Header bar ─────────────────────────────────────────── -->
-    <rect x="4" y="4" width="112" height="14" fill="#0D1117" opacity="0.95"/>
+    <rect x="4" y="4" width="112" height="14" fill="#0D1117" opacity="0.98"/>
     <line x1="4" y1="18" x2="116" y2="18" stroke="#243040" stroke-width="0.75"/>
 
     <!-- Status dot — critical blinking indicator -->
     <rect x="10" y="9" width="4" height="4" fill="#C0392B"/>
-    <!-- Label text simulation — small rects acting as text blocks -->
-    <rect x="18" y="10" width="24" height="2" fill="#5A7184" opacity="0.6" rx="0"/>
-    <rect x="46" y="10" width="14" height="2" fill="#3A4F61" opacity="0.5" rx="0"/>
+    <!-- Header label text simulations -->
+    <rect x="18" y="10" width="22" height="2" fill="#5A7184" opacity="0.6"/>
+    <rect x="44" y="10" width="12" height="2" fill="#3A4F61" opacity="0.5"/>
+    <!-- GC / SENTINEL right label -->
+    <rect x="84" y="10" width="26" height="2" fill="#3A4F61" opacity="0.4"/>
 
-    <!-- GC / SENTINEL label — top right -->
-    <rect x="82" y="10" width="28" height="2" fill="#3A4F61" opacity="0.4" rx="0"/>
+    <!-- ── Background grid ────────────────────────────────────── -->
+    <!-- Horizontal scan lines -->
+    <line x1="4"   y1="30" x2="116" y2="30" stroke="#1A2230" stroke-width="0.5"/>
+    <line x1="4"   y1="42" x2="116" y2="42" stroke="#1A2230" stroke-width="0.5"/>
+    <line x1="4"   y1="54" x2="116" y2="54" stroke="#1A2230" stroke-width="0.5"/>
+    <line x1="4"   y1="66" x2="116" y2="66" stroke="#1A2230" stroke-width="0.5"/>
+    <line x1="4"   y1="78" x2="78"  y2="78" stroke="#1A2230" stroke-width="0.5"/>
+
+    <!-- Vertical divisions -->
+    <line x1="26"  y1="18" x2="26"  y2="78" stroke="#1A2230" stroke-width="0.5"/>
+    <line x1="48"  y1="18" x2="48"  y2="78" stroke="#1A2230" stroke-width="0.5"/>
+    <line x1="70"  y1="18" x2="70"  y2="78" stroke="#1A2230" stroke-width="0.5"/>
+
+    <!-- ── Radar scan area (left ⅔ of icon, rows 18–78) ───────── -->
+    <!-- Origin at (14, 72) — sweep covers upper-right quadrant -->
+
+    <!-- Sweep fill wedge -->
+    <path
+      d="M 14 72
+         L 14 24
+         A 48 48 0 0 1 62 72
+         Z"
+      fill="url(#s-sweep)"
+      opacity="0.22"
+    />
+
+    <!-- Sweep leading edge line — main beam -->
+    <line x1="14" y1="72" x2="62" y2="24"
+      stroke="#4A8FBF" stroke-width="1.25" opacity="0.6"/>
+
+    <!-- Secondary ghost sweep line — trailing edge -->
+    <line x1="14" y1="72" x2="68" y2="36"
+      stroke="#4A8FBF" stroke-width="0.5" opacity="0.2"/>
+
+    <!-- Concentric range rings — quarter arcs -->
+    <path d="M 14 56  A 16 16 0 0 1 30 72" stroke="#243040" stroke-width="0.75" fill="none"/>
+    <path d="M 14 40  A 32 32 0 0 1 46 72" stroke="#243040" stroke-width="0.75" fill="none"/>
+    <path d="M 14 24  A 48 48 0 0 1 62 72" stroke="#243040" stroke-width="0.75" fill="none"/>
+
+    <!-- Range ring tick marks — horizontal axis -->
+    <line x1="14" y1="56" x2="18" y2="56" stroke="#4A8FBF" stroke-width="0.75" opacity="0.5"/>
+    <line x1="14" y1="40" x2="18" y2="40" stroke="#4A8FBF" stroke-width="0.75" opacity="0.5"/>
+    <line x1="14" y1="24" x2="18" y2="24" stroke="#4A8FBF" stroke-width="0.75" opacity="0.4"/>
+    <!-- Vertical axis ticks -->
+    <line x1="30" y1="72" x2="30" y2="68" stroke="#4A8FBF" stroke-width="0.75" opacity="0.5"/>
+    <line x1="46" y1="72" x2="46" y2="68" stroke="#4A8FBF" stroke-width="0.75" opacity="0.5"/>
+    <line x1="62" y1="72" x2="62" y2="68" stroke="#4A8FBF" stroke-width="0.75" opacity="0.4"/>
+
+    <!-- ── Threat classification markers ───────────────────────── -->
+
+    <!-- Target 1 — critical, near range -->
+    <rect x="26" y="56" width="5" height="5" fill="none" stroke="#C0392B" stroke-width="1"/>
+    <!-- Crosshair ticks -->
+    <line x1="28.5" y1="53" x2="28.5" y2="55" stroke="#C0392B" stroke-width="0.75" opacity="0.85"/>
+    <line x1="32"   y1="58.5" x2="34"   y2="58.5" stroke="#C0392B" stroke-width="0.75" opacity="0.85"/>
+    <!-- Outer pulse ring — square -->
+    <rect x="23" y="53" width="11" height="11" fill="none" stroke="#C0392B" stroke-width="0.5" opacity="0.35"/>
+    <!-- Inner fill -->
+    <rect x="27.5" y="57.5" width="2" height="2" fill="#C0392B" opacity="0.5"/>
+
+    <!-- Target 2 — warning, mid range -->
+    <rect x="40" y="36" width="4" height="4" fill="none" stroke="#D68910" stroke-width="0.9"/>
+    <line x1="42" y1="33" x2="42" y2="35" stroke="#D68910" stroke-width="0.75" opacity="0.8"/>
+    <line x1="45" y1="38" x2="47" y2="38" stroke="#D68910" stroke-width="0.75" opacity="0.8"/>
+
+    <!-- Target 3 — pass, far range (cleared) -->
+    <rect x="54" y="50" width="3" height="3" fill="none" stroke="#1E8449" stroke-width="0.75"/>
+
+    <!-- ── Origin anchor point ─────────────────────────────────── -->
+    <rect x="12" y="70" width="4" height="4" fill="#4A8FBF" opacity="0.75"/>
+    <!-- Axis lines from origin -->
+    <line x1="14" y1="24" x2="14" y2="70" stroke="#4A8FBF" stroke-width="0.5" opacity="0.25"/>
+    <line x1="14" y1="72" x2="62" y2="72" stroke="#4A8FBF" stroke-width="0.5" opacity="0.25"/>
+
+    <!-- ── Right panel divider ─────────────────────────────────── -->
+    <line x1="78" y1="18" x2="78" y2="116" stroke="#243040" stroke-width="0.75"/>
+
+    <!-- ── Right panel: check result rows ─────────────────────── -->
+    <!-- Panel header -->
+    <rect x="78" y="18" width="38" height="10" fill="#131920"/>
+    <line x1="78" y1="28" x2="116" y2="28" stroke="#1A2230" stroke-width="0.75"/>
+    <rect x="82" y="21.5" width="18" height="1.5" fill="#4A8FBF" opacity="0.45"/>
+
+    <!-- Row 1 — DMARC: CRITICAL -->
+    <rect x="78" y="28" width="38" height="12" fill="url(#s-row-crit)"/>
+    <line x1="78" y1="40" x2="116" y2="40" stroke="#1A2230" stroke-width="0.5"/>
+    <rect x="82" y="31" width="3" height="3" fill="#C0392B"/>
+    <rect x="88" y="30" width="20" height="2" fill="#E8EDF2" opacity="0.5"/>
+    <rect x="88" y="34" width="14" height="1.5" fill="#5A7184" opacity="0.3"/>
+    <!-- CRITICAL badge -->
+    <rect x="104" y="30" width="8" height="4" fill="none" stroke="#C0392B" stroke-width="0.5" opacity="0.7"/>
+    <rect x="105" y="31" width="6" height="2" fill="#C0392B" opacity="0.35"/>
+
+    <!-- Row 2 — SPF: PASS -->
+    <line x1="78" y1="52" x2="116" y2="52" stroke="#1A2230" stroke-width="0.5"/>
+    <rect x="82" y="43" width="3" height="3" fill="#1E8449"/>
+    <rect x="88" y="42" width="16" height="2" fill="#E8EDF2" opacity="0.4"/>
+    <rect x="88" y="46" width="12" height="1.5" fill="#5A7184" opacity="0.25"/>
+    <rect x="104" y="42" width="8" height="4" fill="none" stroke="#1E8449" stroke-width="0.5" opacity="0.5"/>
+    <rect x="105" y="43" width="6" height="2" fill="#1E8449" opacity="0.25"/>
+
+    <!-- Row 3 — SSL: WARNING -->
+    <line x1="78" y1="64" x2="116" y2="64" stroke="#1A2230" stroke-width="0.5"/>
+    <rect x="82" y="55" width="3" height="3" fill="#D68910"/>
+    <rect x="88" y="54" width="18" height="2" fill="#E8EDF2" opacity="0.35"/>
+    <rect x="88" y="58" width="10" height="1.5" fill="#5A7184" opacity="0.22"/>
+    <rect x="104" y="54" width="8" height="4" fill="none" stroke="#D68910" stroke-width="0.5" opacity="0.5"/>
+    <rect x="105" y="55" width="6" height="2" fill="#D68910" opacity="0.25"/>
+
+    <!-- Row 4 — DKIM: PASS -->
+    <line x1="78" y1="76" x2="116" y2="76" stroke="#1A2230" stroke-width="0.5"/>
+    <rect x="82" y="67" width="3" height="3" fill="#1E8449"/>
+    <rect x="88" y="66" width="14" height="2" fill="#E8EDF2" opacity="0.3"/>
+    <rect x="88" y="70" width="16" height="1.5" fill="#5A7184" opacity="0.2"/>
+    <rect x="104" y="66" width="8" height="4" fill="none" stroke="#1E8449" stroke-width="0.5" opacity="0.4"/>
+    <rect x="105" y="67" width="6" height="2" fill="#1E8449" opacity="0.2"/>
+
+    <!-- ── Signal trace / waveform — spans full width at y≈78 ─── -->
+    <line x1="4" y1="78" x2="116" y2="78" stroke="#243040" stroke-width="0.75"/>
+    <rect x="4" y="78" width="112" height="28" fill="#0D1117"/>
+
+    <!-- Waveform with anomaly spike -->
+    <polyline
+      points="4,90 16,90 20,90 24,85 27,94 31,87 34,90 44,90 48,90 50,76 52,90 56,90 72,90 76,90 80,84 84,97 88,88 92,90 116,90"
+      stroke="url(#s-trace)" stroke-width="1.25" fill="none"
+    />
+
+    <!-- Spike highlight — the critical anomaly -->
+    <line x1="50" y1="78" x2="50" y2="89" stroke="#C0392B" stroke-width="1" opacity="0.85"/>
+    <!-- Anomaly marker — square dot at peak -->
+    <rect x="48.5" y="75" width="3" height="3" fill="#C0392B" opacity="0.9"/>
+    <!-- Outer pulse ring -->
+    <rect x="46" y="73" width="8" height="7" fill="none" stroke="#C0392B" stroke-width="0.5" opacity="0.35"/>
+
+    <!-- Warning spike marker -->
+    <line x1="80" y1="84" x2="80" y2="89" stroke="#D68910" stroke-width="0.75" opacity="0.7"/>
+    <rect x="79" y="82" width="2.5" height="2.5" fill="#D68910" opacity="0.6"/>
+
+    <!-- Waveform row label blocks -->
+    <rect x="8"  y="104" width="12" height="1.5" fill="#4A8FBF" opacity="0.4"/>
+    <rect x="24" y="104" width="18" height="1.5" fill="#3A4F61" opacity="0.3"/>
+    <rect x="60" y="104" width="20" height="1.5" fill="#3A4F61" opacity="0.25"/>
 
     <!-- ── Footer bar ─────────────────────────────────────────── -->
-    <rect x="4" y="106" width="112" height="10" fill="#0D1117" opacity="0.9"/>
+    <rect x="4" y="106" width="112" height="10" fill="#0D1117" opacity="0.95"/>
     <line x1="4" y1="106" x2="116" y2="106" stroke="#243040" stroke-width="0.75"/>
 
     <!-- Footer data readouts -->
-    <rect x="10" y="109" width="18" height="1.5" fill="#3A4F61" opacity="0.5"/>
-    <rect x="32" y="109" width="12" height="1.5" fill="#4A8FBF" opacity="0.4"/>
-    <rect x="88" y="109" width="22" height="1.5" fill="#3A4F61" opacity="0.4"/>
-
-    <!-- ── Origin anchor point ─────────────────────────────────── -->
-    <rect x="12" y="104" width="4" height="4" fill="#4A8FBF" opacity="0.7"/>
-    <line x1="14" y1="22"  x2="14" y2="104" stroke="#4A8FBF" stroke-width="0.5" opacity="0.3"/>
-    <line x1="14" y1="106" x2="98" y2="106" stroke="#4A8FBF" stroke-width="0.5" opacity="0.3"/>
+    <rect x="10" y="109" width="16" height="1.5" fill="#3A4F61" opacity="0.5"/>
+    <rect x="30" y="109" width="8"  height="1.5" fill="#4A8FBF" opacity="0.4"/>
+    <rect x="42" y="109" width="22" height="1.5" fill="#3A4F61" opacity="0.35"/>
+    <rect x="88" y="109" width="22" height="1.5" fill="#3A4F61" opacity="0.35"/>
 
   </g>
 
-  <!-- ── Outer accent corner — top right ────────────────────── -->
+  <!-- ── Outer accent corner — top right (redrawn over clip) ── -->
   <polyline points="96,4 112,4 112,20" stroke="#4A8FBF" stroke-width="1" opacity="0.6"/>
 
 </svg>

--- a/public/icons/sentinel.svg
+++ b/public/icons/sentinel.svg
@@ -1,0 +1,143 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" width="120" height="120" fill="none">
+  <defs>
+    <!-- Subtle depth gradient for background panel -->
+    <linearGradient id="s-bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0D1117"/>
+      <stop offset="100%" stop-color="#080B0F"/>
+    </linearGradient>
+
+    <!-- Sweep arc gradient — accent fading to transparent -->
+    <linearGradient id="s-sweep" x1="1" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#4A8FBF" stop-opacity="0.55"/>
+      <stop offset="100%" stop-color="#4A8FBF" stop-opacity="0"/>
+    </linearGradient>
+
+    <!-- Signal trace gradient -->
+    <linearGradient id="s-trace" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#4A8FBF" stop-opacity="0"/>
+      <stop offset="40%" stop-color="#4A8FBF" stop-opacity="0.7"/>
+      <stop offset="100%" stop-color="#4A8FBF" stop-opacity="0.15"/>
+    </linearGradient>
+
+    <!-- Clip to icon bounds -->
+    <clipPath id="s-clip">
+      <rect x="4" y="4" width="112" height="112"/>
+    </clipPath>
+  </defs>
+
+  <!-- ── Outer frame ─────────────────────────────────────────── -->
+  <rect x="4" y="4" width="112" height="112" fill="url(#s-bg)" stroke="#243040" stroke-width="1"/>
+
+  <!-- Corner cut mark — top right -->
+  <polyline points="96,4 112,4 112,20" stroke="#4A8FBF" stroke-width="1" opacity="0.6"/>
+  <!-- Corner mark — bottom left -->
+  <polyline points="24,116 4,116 4,100" stroke="#243040" stroke-width="1" opacity="0.5"/>
+
+  <!-- ── Inner scan field (clipped) ─────────────────────────── -->
+  <g clip-path="url(#s-clip)">
+
+    <!-- Background grid — horizontal scan lines -->
+    <line x1="4"  y1="28" x2="116" y2="28" stroke="#1A2230" stroke-width="0.5"/>
+    <line x1="4"  y1="44" x2="116" y2="44" stroke="#1A2230" stroke-width="0.5"/>
+    <line x1="4"  y1="60" x2="116" y2="60" stroke="#1A2230" stroke-width="0.5"/>
+    <line x1="4"  y1="76" x2="116" y2="76" stroke="#1A2230" stroke-width="0.5"/>
+    <line x1="4"  y1="92" x2="116" y2="92" stroke="#1A2230" stroke-width="0.5"/>
+
+    <!-- Background grid — vertical divisions -->
+    <line x1="26"  y1="4" x2="26"  y2="116" stroke="#1A2230" stroke-width="0.5"/>
+    <line x1="48"  y1="4" x2="48"  y2="116" stroke="#1A2230" stroke-width="0.5"/>
+    <line x1="70"  y1="4" x2="70"  y2="116" stroke="#1A2230" stroke-width="0.5"/>
+    <line x1="92"  y1="4" x2="92"  y2="116" stroke="#1A2230" stroke-width="0.5"/>
+
+    <!-- ── Radar sweep quadrant (origin: bottom-left corner of scan field) ── -->
+    <!-- Origin at (4, 116) — sweep covers upper-right quadrant -->
+
+    <!-- Sweep fill wedge — quarter circle arc -->
+    <!-- Drawn as a pie slice from origin -->
+    <path
+      d="M 14 106
+         L 14 22
+         A 84 84 0 0 1 98 106
+         Z"
+      fill="url(#s-sweep)"
+      opacity="0.18"
+    />
+
+    <!-- Sweep leading edge line -->
+    <line x1="14" y1="106" x2="80" y2="28"
+      stroke="#4A8FBF" stroke-width="1" opacity="0.55"/>
+
+    <!-- Concentric range rings — quarter arcs from origin (14,106) -->
+    <path d="M 14 78  A 28 28 0 0 1 42 106" stroke="#243040" stroke-width="0.75" fill="none"/>
+    <path d="M 14 50  A 56 56 0 0 1 70 106" stroke="#243040" stroke-width="0.75" fill="none"/>
+    <path d="M 14 22  A 84 84 0 0 1 98 106" stroke="#243040" stroke-width="0.75" fill="none"/>
+
+    <!-- Range ring accent ticks -->
+    <line x1="14" y1="78" x2="18" y2="78" stroke="#4A8FBF" stroke-width="0.75" opacity="0.5"/>
+    <line x1="14" y1="50" x2="18" y2="50" stroke="#4A8FBF" stroke-width="0.75" opacity="0.5"/>
+    <line x1="42" y1="106" x2="42" y2="102" stroke="#4A8FBF" stroke-width="0.75" opacity="0.5"/>
+    <line x1="70" y1="106" x2="70" y2="102" stroke="#4A8FBF" stroke-width="0.75" opacity="0.5"/>
+
+    <!-- ── Signal trace / waveform — horizontal ────────────────── -->
+    <!-- Drawn along y=60, showing an anomaly spike -->
+    <polyline
+      points="4,60 20,60 26,60 30,54 34,67 38,57 42,60 54,60 58,60 60,44 62,60 66,60 92,60 116,60"
+      stroke="url(#s-trace)" stroke-width="1.25" fill="none"
+    />
+
+    <!-- Spike highlight — the anomaly peak -->
+    <line x1="60" y1="46" x2="60" y2="58" stroke="#4A8FBF" stroke-width="1" opacity="0.9"/>
+    <!-- Anomaly marker — small square dot -->
+    <rect x="58.5" y="43" width="3" height="3" fill="#4A8FBF" opacity="0.9"/>
+
+    <!-- ── Threat classification markers ───────────────────────── -->
+
+    <!-- Target 1 — critical, near sweep origin area -->
+    <rect x="38" y="82" width="4" height="4" fill="none" stroke="#C0392B" stroke-width="1"/>
+    <!-- Cross-hair lines for target 1 -->
+    <line x1="40" y1="79" x2="40" y2="81" stroke="#C0392B" stroke-width="0.75" opacity="0.8"/>
+    <line x1="43" y1="84" x2="45" y2="84" stroke="#C0392B" stroke-width="0.75" opacity="0.8"/>
+    <!-- Blinking pulse ring -->
+    <rect x="35" y="79" width="10" height="10" fill="none" stroke="#C0392B" stroke-width="0.5" opacity="0.4"/>
+
+    <!-- Target 2 — warning, mid-range -->
+    <rect x="64" y="50" width="4" height="4" fill="none" stroke="#D68910" stroke-width="1"/>
+    <line x1="66" y1="47" x2="66" y2="49" stroke="#D68910" stroke-width="0.75" opacity="0.8"/>
+    <line x1="69" y1="52" x2="71" y2="52" stroke="#D68910" stroke-width="0.75" opacity="0.8"/>
+
+    <!-- Target 3 — pass, far range -->
+    <rect x="84" y="76" width="3" height="3" fill="none" stroke="#1E8449" stroke-width="0.75"/>
+
+    <!-- ── Header bar ─────────────────────────────────────────── -->
+    <rect x="4" y="4" width="112" height="14" fill="#0D1117" opacity="0.95"/>
+    <line x1="4" y1="18" x2="116" y2="18" stroke="#243040" stroke-width="0.75"/>
+
+    <!-- Status dot — critical blinking indicator -->
+    <rect x="10" y="9" width="4" height="4" fill="#C0392B"/>
+    <!-- Label text simulation — small rects acting as text blocks -->
+    <rect x="18" y="10" width="24" height="2" fill="#5A7184" opacity="0.6" rx="0"/>
+    <rect x="46" y="10" width="14" height="2" fill="#3A4F61" opacity="0.5" rx="0"/>
+
+    <!-- GC / SENTINEL label — top right -->
+    <rect x="82" y="10" width="28" height="2" fill="#3A4F61" opacity="0.4" rx="0"/>
+
+    <!-- ── Footer bar ─────────────────────────────────────────── -->
+    <rect x="4" y="106" width="112" height="10" fill="#0D1117" opacity="0.9"/>
+    <line x1="4" y1="106" x2="116" y2="106" stroke="#243040" stroke-width="0.75"/>
+
+    <!-- Footer data readouts -->
+    <rect x="10" y="109" width="18" height="1.5" fill="#3A4F61" opacity="0.5"/>
+    <rect x="32" y="109" width="12" height="1.5" fill="#4A8FBF" opacity="0.4"/>
+    <rect x="88" y="109" width="22" height="1.5" fill="#3A4F61" opacity="0.4"/>
+
+    <!-- ── Origin anchor point ─────────────────────────────────── -->
+    <rect x="12" y="104" width="4" height="4" fill="#4A8FBF" opacity="0.7"/>
+    <line x1="14" y1="22"  x2="14" y2="104" stroke="#4A8FBF" stroke-width="0.5" opacity="0.3"/>
+    <line x1="14" y1="106" x2="98" y2="106" stroke="#4A8FBF" stroke-width="0.5" opacity="0.3"/>
+
+  </g>
+
+  <!-- ── Outer accent corner — top right ────────────────────── -->
+  <polyline points="96,4 112,4 112,20" stroke="#4A8FBF" stroke-width="1" opacity="0.6"/>
+
+</svg>

--- a/src/components/sections/home/EuropeTrustBar.astro
+++ b/src/components/sections/home/EuropeTrustBar.astro
@@ -24,7 +24,7 @@ const facts = [
 ];
 ---
 
-<section class="border-b border-border-base bg-bg-overlay noise px-6 py-16">
+<section class="border-b border-border-base bg-bg-overlay noise px-6 py-12">
   <div class="max-w-7xl mx-auto">
 
     <!-- Header row -->
@@ -47,7 +47,7 @@ const facts = [
     <div class="grid grid-cols-2 md:grid-cols-4 gap-0 border border-border-base">
       {facts.map((fact, i) => (
         <div class:list={[
-          "px-6 py-8",
+          "px-8 py-10",
           i < facts.length - 1 && "border-b md:border-b-0 md:border-r border-border-base",
         ]}>
           <p class="font-mono text-xs text-text-dim uppercase tracking-widest mb-2">

--- a/src/components/sections/home/HeroHome.astro
+++ b/src/components/sections/home/HeroHome.astro
@@ -21,7 +21,7 @@ const statusDotColor = {
 <section class="
   relative min-h-[calc(100vh-3.5rem)] flex flex-col justify-center
   bg-bg-base noise border-b border-border-base
-  px-6 py-24 overflow-hidden
+  px-6 pt-32 pb-40 overflow-hidden
 ">
 
   <!-- Background grid -->
@@ -55,7 +55,7 @@ const statusDotColor = {
           font-display font-bold uppercase
           text-5xl md:text-6xl xl:text-7xl
           text-text-primary
-          leading-[1.02] tracking-tight mb-8
+          leading-[1.02] tracking-tight mb-12
         ">
           Your IT<br />
           operations,<br />
@@ -72,7 +72,7 @@ const statusDotColor = {
           without enterprise complexity or US data residency.
         </p>
 
-        <div class="flex flex-wrap items-center gap-3 mb-12">
+        <div class="flex flex-wrap items-center gap-3 mb-14">
           <Button href="/sentinel">Start with Sentinel →</Button>
           <Button href="#products" variant="ghost">See all products</Button>
         </div>

--- a/src/components/sections/home/PricingTeaser.astro
+++ b/src/components/sections/home/PricingTeaser.astro
@@ -9,7 +9,7 @@ const tiers = [
 ] as const;
 ---
 
-<section class="border-b border-border-base bg-bg-raised noise px-6 py-24">
+<section class="border-b border-border-base bg-bg-raised noise px-6 py-20">
   <div class="max-w-3xl mx-auto text-center">
 
     <!-- Centered section marker variant -->

--- a/src/components/sections/home/ProblemStrip.astro
+++ b/src/components/sections/home/ProblemStrip.astro
@@ -27,7 +27,7 @@ const problems = [
 ];
 ---
 
-<section class="border-b border-border-base bg-bg-raised px-6 py-24">
+<section class="border-b border-border-base bg-bg-raised px-6 py-20">
   <div class="max-w-7xl mx-auto">
 
     <SectionMarker label="01 / The Problem" />
@@ -49,14 +49,9 @@ const problems = [
             {p.headline}
           </h2>
 
-          <!-- Body -->
-          <p class="font-body text-sm text-text-muted leading-relaxed flex-1">
-            {p.body}
-          </p>
-
           <!-- Stat -->
           <div class="border-t border-border-dim pt-6">
-            <div class="font-display font-bold text-3xl text-accent mb-1">
+            <div class="font-display font-bold text-4xl text-accent mb-1">
               {p.stat}
             </div>
             <div class="font-mono text-xs text-text-dim leading-relaxed">

--- a/src/components/sections/home/ProductSuite.astro
+++ b/src/components/sections/home/ProductSuite.astro
@@ -7,13 +7,15 @@ import { StatusDot } from '@/components/ui/StatusDot';
 const products = [
   {
     id:       'sentinel',
+    code:     'S-01',
     name:     'Sentinel',
     tagline:  'Security monitoring',
     status:   'live',
     href:     '/sentinel',
     cta:      'Start free →',
+    icon:     '/icons/sentinel.svg',
     checks: [
-      'DNS & email authentication (SPF, DKIM, DMARC)',
+      'DNS & email authentication',
       'SSL certificate expiry monitoring',
       'Microsoft 365 configuration health',
       'NIS2 Article 21 compliance reports',
@@ -22,31 +24,35 @@ const products = [
   },
   {
     id:       'desk',
+    code:     'D-02',
     name:     'Desk',
     tagline:  'IT service management',
     status:   'beta',
     href:     '/desk',
     cta:      'Join waitlist →',
+    icon:     '/icons/desk.svg',
     checks: [
-      'IT ticket management without the configuration hell',
-      'Service catalog with automated delivery pipelines',
-      'AI-assisted ticket resolution and routing',
+      'IT ticket management',
+      'Service catalog with automated pipelines',
+      'AI-assisted routing',
       'SLA tracking and reporting',
     ],
     indicator: 'Beta — join waitlist',
   },
   {
     id:       'launch',
+    code:     'L-03',
     name:     'Launch',
     tagline:  'Cloud deployment',
     status:   'soon',
     href:     '/launch',
     cta:      'Join waitlist →',
+    icon:     '/icons/launch.svg',
     checks: [
-      'Preview environments per GitHub PR on Cloud Run',
-      'Secrets management without the configuration overhead',
-      'Bucket provisioning wired to deployments',
-      'Team-level deployment controls and audit log',
+      'PR preview environments on Cloud Run',
+      'Secrets management',
+      'Bucket provisioning',
+      'Team-level deployment controls',
     ],
     indicator: 'Coming soon',
   },
@@ -59,25 +65,42 @@ const statusConfig = {
 };
 ---
 
-<section id="products" class="border-b border-border-base bg-bg-base px-6 py-24">
+<section id="products" class="border-b border-border-base bg-bg-base px-6 pt-32 pb-36">
   <div class="max-w-7xl mx-auto">
 
     <SectionMarker label="02 / Products" />
 
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-0 border border-border-base">
+    <div class="mt-12 grid grid-cols-1 md:grid-cols-3 gap-0 border border-border-base">
       {products.map((p, i) => {
         const cfg = statusConfig[p.status];
         const isLive = p.status === 'live';
         return (
           <div class:list={[
-            "flex flex-col",
+            "flex flex-col relative",
             i < products.length - 1 && "border-b md:border-b-0 md:border-r border-border-base",
-            !isLive && "opacity-70",
+            isLive ? "bg-bg-raised border-l-2 border-l-accent" : "bg-bg-base",
           ]}>
 
+            <!-- Watermark code -->
+            <span class="absolute top-6 right-6 font-mono text-5xl font-bold text-text-dim opacity-10 leading-none select-none pointer-events-none">
+              {p.code}
+            </span>
+
+            <!-- Product icon -->
+            <div class="px-6 pt-8 pb-0">
+              <img
+                src={p.icon}
+                alt={`${p.name} product illustration`}
+                width="120"
+                height="120"
+                class="w-[120px] h-[120px]"
+                loading="lazy"
+              />
+            </div>
+
             <!-- Card header -->
-            <div class="px-6 pt-8 pb-6 border-b border-border-dim">
-              <div class="flex items-center justify-between mb-4">
+            <div class="px-6 pt-5 pb-6 border-b border-border-dim">
+              <div class="flex items-center justify-between mb-3">
                 <div class="flex items-center gap-2">
                   <StatusDot color={cfg.color} blink={cfg.blink} />
                   <span class:list={["font-mono text-xs uppercase tracking-widest", cfg.labelClass]}>
@@ -98,17 +121,17 @@ const statusConfig = {
             </div>
 
             <!-- Check list -->
-            <div class="px-6 py-6 flex-1 space-y-3">
+            <div class="px-6 py-8 flex-1 space-y-4">
               {p.checks.map(check => (
                 <div class="flex items-start gap-3">
-                  <StatusDot color="muted" size="xs" className="mt-1.5" />
+                  <StatusDot color="muted" size="xs" className="mt-1.5 shrink-0" />
                   <span class="font-body text-sm text-text-muted leading-snug">{check}</span>
                 </div>
               ))}
             </div>
 
             <!-- Card footer / CTA -->
-            <div class="px-6 pb-8">
+            <div class="px-6 pb-8 border-t border-border-dim pt-8">
               <Button
                 href={p.href}
                 variant={isLive ? 'primary' : 'ghost'}

--- a/src/components/sections/home/SentinelSpotlight.astro
+++ b/src/components/sections/home/SentinelSpotlight.astro
@@ -43,7 +43,7 @@ const dotClass = {
 } as const;
 ---
 
-<section class="border-b border-border-base bg-bg-base px-6 py-24">
+<section class="border-b border-border-base bg-bg-base px-6 py-32">
   <div class="max-w-7xl mx-auto">
     <SectionMarker label="03 / Product Suite" />
 
@@ -142,30 +142,16 @@ const dotClass = {
           authentication, and certificates — continuously, not on demand.
         </p>
 
-        <div class="space-y-4 mb-10">
+        <div class="space-y-5 mb-10">
           {
             [
-              {
-                label: "Checks run every 6 hours",
-                detail: "SPF, DKIM, DMARC, SSL, MX, M365 configuration — from the attacker's perspective.",
-              },
-              {
-                label: "Alert before it becomes an incident",
-                detail: "Email, Slack, webhook, or Microsoft Teams when anything changes or degrades.",
-              },
-              {
-                label: "NIS2 compliance report on demand",
-                detail: "Export a PDF mapped to Article 21. Share with customers or auditors.",
-              },
-            ].map((item) => (
-              <div class="flex gap-4 items-start">
-                <StatusDot color="accent" size="xs" className="mt-2" />
-                <div>
-                  <p class="font-mono text-sm text-text-primary mb-0.5">
-                    {item.label}
-                  </p>
-                  <p class="font-body text-xs text-text-muted">{item.detail}</p>
-                </div>
+              "Checks run every 6 hours",
+              "Alert before it becomes an incident",
+              "NIS2 compliance report on demand",
+            ].map((label) => (
+              <div class="flex gap-4 items-center">
+                <StatusDot color="accent" size="xs" />
+                <p class="font-mono text-sm text-text-primary">{label}</p>
               </div>
             ))
           }

--- a/src/components/ui/SectionDivider.astro
+++ b/src/components/ui/SectionDivider.astro
@@ -1,0 +1,28 @@
+---
+// SectionDivider.astro — HUD-style chapter break between major sections
+interface Props {
+  sector: string;   // e.g. "02 / PRODUCTS"
+  coord?: string;   // e.g. "N 45°28′ / E 09°11′"
+  bg?: string;      // tailwind bg class to match parent section below
+}
+
+const {
+  sector,
+  coord = '',
+  bg = 'bg-bg-base',
+} = Astro.props;
+---
+
+<div class:list={["w-full border-y border-border-base", bg]}>
+  <div class="max-w-7xl mx-auto px-6 py-2 flex items-center justify-between">
+    <span class="font-mono text-[10px] text-text-dim uppercase tracking-widest">
+      {sector}
+    </span>
+    {coord && (
+      <span class="font-mono text-[10px] text-text-dim hidden sm:block">
+        {coord}
+      </span>
+    )}
+    <span class="font-mono text-[10px] text-text-dim uppercase tracking-widest">GC-HOME</span>
+  </div>
+</div>

--- a/src/components/ui/SectionMarker.tsx
+++ b/src/components/ui/SectionMarker.tsx
@@ -5,7 +5,7 @@ interface SectionMarkerProps {
 
 export function SectionMarker({ label, className = '' }: SectionMarkerProps) {
   return (
-    <div className={['flex items-center gap-3 mb-6', className].filter(Boolean).join(' ')}>
+    <div className={['flex items-center gap-3 mb-10', className].filter(Boolean).join(' ')}>
       <div className="w-8 h-px bg-accent" />
       <span className="font-mono text-xs text-accent uppercase tracking-widest">
         {label}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,6 +6,7 @@ import ProductSuite      from '../components/sections/home/ProductSuite.astro';
 import EuropeTrustBar    from '../components/sections/home/EuropeTrustBar.astro';
 import SentinelSpotlight from '../components/sections/home/SentinelSpotlight.astro';
 import PricingTeaser     from '../components/sections/home/PricingTeaser.astro';
+import SectionDivider    from '../components/ui/SectionDivider.astro';
 ---
 
 <Layout
@@ -14,9 +15,14 @@ import PricingTeaser     from '../components/sections/home/PricingTeaser.astro';
   canonical="https://groundcontrol.land"
 >
   <HeroHome />
+  <SectionDivider sector="01 / The Problem" coord="N 45°28′ / E 09°11′" bg="bg-bg-raised" />
   <ProblemStrip />
+  <SectionDivider sector="02 / Products" coord="N 41°54′ / E 12°29′" bg="bg-bg-base" />
   <ProductSuite />
+  <SectionDivider sector="03 / Built for Europe" coord="N 48°08′ / E 11°34′" bg="bg-bg-overlay" />
   <EuropeTrustBar />
+  <SectionDivider sector="04 / Product Suite" coord="N 52°31′ / E 13°24′" bg="bg-bg-base" />
   <SentinelSpotlight />
+  <SectionDivider sector="05 / Pricing" coord="N 43°46′ / E 11°15′" bg="bg-bg-raised" />
   <PricingTeaser />
 </Layout>


### PR DESCRIPTION
- Add rich SVG product illustrations for Sentinel, Desk and Launch,
  styled in aerospace HUD aesthetic (radar sweep, ticket queue, deploy pipeline)
- Integrate product icons into ProductSuite cards with card-cut frame
- Add S-01/D-02/L-03 watermark codes on each product card
- Promote Sentinel card with accent left border; replace opacity-70 on
  non-live cards with bg-bg-base background treatment
- Shorten product card check list to tighter noun phrases
- Remove dense body copy from ProblemStrip; let stat numbers carry persuasion
- Upgrade stat number size from text-3xl → text-4xl
- Remove redundant detail lines from SentinelSpotlight bullets
- Add SectionDivider component: HUD chapter-break bar with sector label
  and European coordinate reference between every major section
- Increase SectionMarker bottom margin mb-6 → mb-10
- Apply three-tier section spacing rhythm:
    Hero py-24 → pt-32 pb-40
    ProblemStrip py-24 → py-20
    ProductSuite py-24 → pt-32 pb-36
    EuropeTrustBar py-16 → py-12 (tighter fact band)
    SentinelSpotlight py-24 → py-32
    PricingTeaser py-24 → py-20
- Increase EuropeTrustBar fact cells px-6 py-8 → px-8 py-10
- Increase h1 margin mb-8 → mb-12, CTA row mb-12 → mb-14

https://claude.ai/code/session_01PmzNHWenpyymXwnUUGwNpf